### PR TITLE
Add user authentication story doc and test

### DIFF
--- a/docs/stories/1.2-user-authentication-setup.md
+++ b/docs/stories/1.2-user-authentication-setup.md
@@ -1,0 +1,14 @@
+**Status:** Draft
+
+**Story:**
+As a **User**,
+I want to **be able to sign up and log in to the application**,
+so that **I can securely access my dashboard and analysis features.**
+
+**Acceptance Criteria:**
+1. A basic login/signup UI is created with fields for email and password.
+2. The UI components integrate with the Supabase Auth client for user sign-up and sign-in functionality.
+3. Upon successful login, the user is redirected to the `/dashboard` page.
+4. The `middleware.ts` file is implemented to protect the `/dashboard` route, redirecting unauthenticated users to the login page.
+5. The logged-in user's session is successfully established using the secure cookie method provided by Supabase.
+6. A "Log Out" button is present and functional, clearing the user's session and redirecting them to the login page.

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "test": "node --test test"
+  },
   "dependencies": {
     "bmad-method": "^4.41.0"
   }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,0 +1,6 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+test('basic arithmetic', () => {
+  assert.strictEqual(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary
- add draft story describing user authentication setup and acceptance criteria
- add placeholder test and npm script to enable `npm test`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae8ab7e890832f8f217bc0f26d3101