### PR TITLE
docs: add findings view story

### DIFF
--- a/docs/stories/1.4-display-analysis-findings-ui.md
+++ b/docs/stories/1.4-display-analysis-findings-ui.md
@@ -1,0 +1,26 @@
+**Status:** Draft
+
+**Story:**
+As a **logged-in User**,
+I want to **view the detailed results of a specific analysis**,
+so that **I can understand the compliance findings for my contract.**
+
+**Acceptance Criteria:**
+1. A "Findings View" page is created at the dynamic route `/analyses/[id]`.
+2. On page load, the frontend uses the `analysisId` from the URL to fetch data from the `GET /analyses/{analysisId}` and `GET /analyses/{analysisId}/findings` endpoints using the appropriate React Query hooks.
+3. While data is loading, the skeleton loader UI, as designed in the UI/UX Specification, is displayed.
+4. If either API call returns an error, a user-friendly error message is displayed on the page.
+5. When data is loaded, the page header correctly displays the contract's name and the "Export Report" button.
+6. The "Verdict Summary Chips" are displayed with the correct counts and are functional, filtering the main findings table when clicked.
+7. The "Findings Table" is rendered, displaying a row for each finding with its detector name and verdict, matching the wireframe design.
+8. Clicking on a finding row opens the "Evidence Drawer" component, which correctly displays the snippet, rationale, and other details for that specific finding.
+
+## Testing
+- [ ] QA test agent verifies data fetching handles success and error states (AC: 2,4)
+- [ ] QA test agent checks skeleton loader displays during loading (AC: 3)
+- [ ] QA test agent confirms header and export button render correctly (AC: 5)
+- [ ] QA test agent tests verdict chips filter findings table (AC: 6)
+- [ ] QA test agent ensures evidence drawer shows correct details (AC: 7,8)
+
+## QA Results
+_Pending QA review_


### PR DESCRIPTION
## Summary
- document story for user-facing analysis findings view
- outline QA testing tasks and add placeholder QA results section

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae8d6cf670832f8a4d9be86a412d7f