### PR TITLE
Add expert-agent MVP and dev cycle workflow docs

### DIFF
--- a/docs/architecture/dev_cycle_workflow.md
+++ b/docs/architecture/dev_cycle_workflow.md
@@ -1,0 +1,42 @@
+# Dev Cycle Workflow
+
+This document describes an iterative development cycle driven by the Scrum Master. The cycle routes work through a VibeCEO checkpoint, gathers testing metrics, and returns to the developer until quality gates pass.
+
+## Roles
+
+1. **Scrum Master** – facilitates the cycle and prioritizes work.
+2. **VibeCEO** – clarifies vision, sets tone, and approves scope before development proceeds.
+3. **QA Analyst** – collects and reports test metrics to measure progress.
+4. **Developer** – implements changes and addresses feedback.
+
+## Workflow Overview
+
+```mermaid
+flowchart TD
+    Start[Backlog Ready] --> SM[Scrum Master Reviews]
+    SM --> VC[VibeCEO Aligns Vision]
+    VC --> QA[Collect Test Metrics]
+    QA --> Dev[Developer Implements]
+    Dev --> Check{Metrics Pass?}
+    Check -->|No| SM
+    Check -->|Yes| Done[Increment Complete]
+```
+
+## Iteration Loop
+
+1. **Scrum Master Review** – selects a backlog item and confirms priority with the VibeCEO.
+2. **Vision Alignment** – VibeCEO ensures the task matches product direction and communicates success vibe.
+3. **Metric Collection** – QA defines or updates test metrics required for acceptance.
+4. **Development** – developer codes against the metrics, running tests locally.
+5. **Evaluation** – metrics are reviewed; failing metrics send the cycle back to the Scrum Master for re‑prioritization and clarification.
+
+## Termination Criteria
+
+The loop ends when the developer's implementation satisfies all test metrics and the VibeCEO confirms alignment. The increment is then ready for integration or release.
+
+## Deliverables
+
+- Updated test metric report
+- Implemented code meeting acceptance metrics
+- Sign-off from Scrum Master and VibeCEO
+

--- a/docs/architecture/expert_agent_workflow.md
+++ b/docs/architecture/expert_agent_workflow.md
@@ -1,0 +1,64 @@
+# Expert Agent Recursive Persona Workflow
+
+This document outlines a conversational workflow for developing a Minimum Viable Product (MVP) using an expert orchestrator agent. The orchestrator iterates through domain personas, capturing their insights until the MVP criteria are satisfied.
+
+## Personas
+
+The workflow models the following personas:
+
+1. **Product Owner** – defines user value and acceptance criteria.
+2. **Architect** – specifies system structure and integration points.
+3. **UX Designer** – sketches user journeys and interface elements.
+4. **Developer** – estimates effort and surfaces technical constraints.
+5. **QA Engineer** – proposes validation scenarios and test cases.
+6. **Release Manager** – ensures deployment and rollback strategies.
+
+## Workflow Overview
+
+```mermaid
+flowchart TD
+    Start[Define MVP Goal] --> Loop
+    Loop{Next Persona?}
+    Loop -->|Yes| Engage[Conduct Persona Conversation]
+    Engage --> Review[Expert Agent Summarizes Output]
+    Review --> Loop
+    Loop -->|No| Build[Implement MVP]
+    Build --> Validate[Run QA Scenarios]
+    Validate --> Deploy[Release MVP]
+```
+
+## Conversation Loop
+
+For each persona, the expert agent runs a structured loop:
+
+1. **Prompt** – the orchestrator explains the current MVP goal and asks persona-specific questions.
+2. **Dialogue** – the persona responds; the orchestrator may ask follow-ups to clarify assumptions or fill gaps.
+3. **Summary** – once the persona's requirements are clear, the orchestrator records the decisions and adds them to the shared backlog.
+4. **Recursion** – the orchestrator proceeds to the next persona, using prior outputs as context.
+
+## Termination Criteria
+
+The recursion ends when every persona signs off on their domain concerns and the backlog contains:
+
+- User stories with acceptance criteria
+- Architecture diagrams or decisions
+- UI sketches or component descriptions
+- Implementation tasks with estimates
+- Test cases
+- Release checklist
+
+## Implementation Notes
+
+- The conversation history forms the audit trail; store it in version control for transparency.
+- The expert agent should surface conflicts between personas and prompt resolution before moving on.
+- When new information arises, the agent may revisit previous personas to refine deliverables, ensuring MVP coherence.
+
+## Deliverables
+
+The final output after completing the workflow includes:
+
+- Consolidated backlog or requirements document
+- Architecture and design artifacts
+- Test plan and release strategy
+- A minimal yet functional product meeting agreed goals
+


### PR DESCRIPTION
## Summary
- Document a workflow where an expert agent iteratively consults domain personas to build an MVP.
- Describe loop structure, termination criteria and deliverables.
- Add development cycle workflow detailing Scrum Master to VibeCEO to metrics to developer until tests pass.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae95dd85e0832fb2b7946963fdb17f