### PR TITLE
docs: add architecture outlines

### DIFF
--- a/docs/api-architecture.md
+++ b/docs/api-architecture.md
@@ -1,0 +1,40 @@
+# API Architecture
+
+## Summary
+
+Describes RESTful contract for Blackletter services and how clients interact with them.
+
+## Design Principles
+
+- **Explicit contracts** via OpenAPI.
+- **Deterministic responses**; no hidden fields.
+- **Versioned** endpoints under `/api` with semantic versioning.
+
+## Core Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/api/contracts` | Ingest a new contract file and create job + analysis IDs. |
+| `GET` | `/api/jobs/{id}` | Poll job status until processing completes. |
+| `GET` | `/api/analyses/{id}` | Retrieve analysis summary and coverage metrics. |
+| `GET` | `/api/analyses/{id}/findings` | Fetch detector findings for a given analysis. |
+| `POST` | `/api/reports/{analysis_id}` | Trigger PDF export and return download URL. |
+
+## Authentication
+
+- Phase‑1: none; local development only.
+- Phase‑2: bearer tokens with minimal Admin/Reviewer roles.
+
+## Error Handling
+
+- Consistent JSON envelope: `{ "detail": str, "code": str }`.
+- 4xx for client issues, 5xx for server faults.
+
+## Rate Limits
+
+- MVP: none.
+- Future: per‑org quotas enforced at gateway.
+
+## Documentation
+
+OpenAPI spec is generated from FastAPI app and published at `/openapi.json`.

--- a/docs/database-architecture.md
+++ b/docs/database-architecture.md
@@ -1,0 +1,31 @@
+# Database Architecture
+
+## Summary
+
+Outlines storage strategy for application data and metadata.
+
+## Engine & Topology
+
+- **SQLite** for local development and automated tests.
+- **PostgreSQL** in Phase‑2 for multi‑user deployments.
+
+## Schema Highlights
+
+- `jobs` – track processing state for uploaded contracts.
+- `analyses` – coverage stats and verdict summaries.
+- `findings` – individual detector results with offsets.
+
+## Migrations
+
+- Managed with Alembic.
+- Linear migration history checked into VCS.
+
+## Indexing & Performance
+
+- Index `jobs.status` and `findings.analysis_id` for fast lookups.
+- Use `GIN` indexes for JSONB fields once on Postgres.
+
+## Backup & Recovery
+
+- Dev: copy SQLite file as artefact.
+- Prod: daily logical dumps + point‑in‑time recovery.

--- a/docs/devops-architecture.md
+++ b/docs/devops-architecture.md
@@ -1,0 +1,31 @@
+# DevOps / Infrastructure Architecture
+
+## Summary
+
+Describes how Blackletter services are built, deployed and observed.
+
+## Environments
+
+- **dev** – local containers and SQLite.
+- **staging** – mirrors prod; used for QA.
+- **prod** – managed deployment with Postgres and object storage.
+
+## CI/CD Pipeline
+
+1. Lint & test on push.
+2. Build backend container image.
+3. Publish artefacts to registry.
+4. Deploy to staging on merge to `main`.
+5. Manual promotion to prod with approval.
+
+## Infrastructure Components
+
+- Container runtime: Docker.
+- Orchestration: minimal `docker compose` in MVP; evaluate Kubernetes later.
+- Secrets managed via environment variables and platform store.
+
+## Observability
+
+- Structured logs with request IDs.
+- Metrics: latency, token usage, explainability percentage.
+- Health probes: `/healthz`, `/readyz`.

--- a/docs/integration-architecture.md
+++ b/docs/integration-architecture.md
@@ -1,0 +1,26 @@
+# Integration Architecture
+
+## Summary
+
+Explains how Blackletter interacts with external systems and services.
+
+## External Services
+
+- **LLM providers** – optional detectors; access abstracted behind `llm_gate`.
+- **Object storage** – store generated PDFs for download links.
+- **Email/Notification services** – future hook for report delivery.
+
+## Patterns
+
+- Prefer synchronous REST calls for Phase‑1 integrations.
+- Use webhooks or message queues for future asynchronous flows.
+
+## Data Exchange
+
+- All data serialized as JSON or multipart form data.
+- Strict schema validation on ingress and egress.
+
+## Resilience
+
+- Timeouts and retries for external calls.
+- Circuit breakers around non-critical integrations.

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -1,0 +1,28 @@
+# Security Architecture
+
+## Summary
+
+Principles and controls safeguarding data and execution.
+
+## Threat Model
+
+- Untrusted contract uploads.
+- Accidental exposure of PII in logs or exports.
+- Unauthorized access to analyses or reports.
+
+## Controls
+
+- Upload validation: MIME/type checks, 10 MB limit, checksum quarantine.
+- Data handling: snippets redacted before any LLM call; no raw snippets logged.
+- Transport: HTTPS everywhere; TLS termination at ingress.
+- Secrets: environment variables with `git-secrets` scanning in CI.
+
+## Access Management
+
+- MVP: single-user local installs.
+- Phase‑2: role-based access (Admin/Reviewer) with audit trails.
+
+## Audit & Monitoring
+
+- Log authentication events and settings changes.
+- Periodic vulnerability scans of container images.


### PR DESCRIPTION
## Summary
- add dedicated API, database, devops, security, and integration architecture docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae7d74e650832f8a4816aa6d901452