### PR TITLE
Add file-bus PowerShell helpers, notifier, and orchestration guide

### DIFF
--- a/docs/fullstack.txt
+++ b/docs/fullstack.txt
@@ -1,0 +1,26 @@
+Full-Stack Agent Orchestration Guide
+===================================
+
+This repository uses a filesystem message bus for coordinating Windows-based agents.
+
+1. Import the bus module and initialize directories:
+   ````powershell
+   Import-Module .\tools\bus.psm1
+   Initialize-Bus
+   ````
+2. Start the tray notifier for your role:
+   ````powershell
+   pwsh .\scripts\Start-Notifier.ps1 -Role orchestrator
+   ````
+3. Send a task to another role:
+   ````powershell
+   Send-Task -To po -From orchestrator -Title "Create story CHK-001"
+   ````
+4. Receive and complete tasks inside the agent loop:
+   ````powershell
+   $t = Receive-Task -Role po
+   # ...process...
+   Complete-Task -Task $t -Status ok -Note "Done"
+   ````
+
+Messages move through `bus/inbox`, `bus/processing`, `bus/outbox`, and `bus/archive` ensuring durable, GitHub-free collaboration.

--- a/scripts/Start-Notifier.ps1
+++ b/scripts/Start-Notifier.ps1
@@ -1,0 +1,49 @@
+# scripts\Start-Notifier.ps1
+param(
+  [ValidateSet("orchestrator","po","architect","backend","frontend","qa","compliance")]
+  [string]$Role = "orchestrator",
+  [string]$BusRoot = (Join-Path $PSScriptRoot "..\bus")
+)
+
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+
+$watchPath = Join-Path $BusRoot "outbox\$Role"
+New-Item -ItemType Directory -Force -Path $watchPath | Out-Null
+
+$icon = New-Object System.Windows.Forms.NotifyIcon
+$icon.Icon = [System.Drawing.SystemIcons]::Information
+$icon.Text = "BMad $Role notifier"
+$icon.Visible = $true
+
+$menu = New-Object System.Windows.Forms.ContextMenuStrip
+$open = $menu.Items.Add("Open outbox")
+$exit = $menu.Items.Add("Exit")
+$icon.ContextMenuStrip = $menu
+
+$open.Add_Click({ ii $watchPath })
+$exit.Add_Click({
+  $icon.Visible = $false
+  $fsw.EnableRaisingEvents = $false
+  $fsw.Dispose()
+  [System.Windows.Forms.Application]::Exit()
+})
+
+$fsw = New-Object System.IO.FileSystemWatcher $watchPath, "*.txt"
+$fsw.IncludeSubdirectories = $false
+$fsw.EnableRaisingEvents = $true
+$fsw.NotifyFilter = [IO.NotifyFilters]'FileName, LastWrite'
+
+$handler = Register-ObjectEvent $fsw Created -Action {
+  Start-Sleep -Milliseconds 120   # allow writer to finish
+  $path = $Event.SourceEventArgs.FullPath
+  try {
+    $first = (Get-Content $path -TotalCount 1)
+    $msg = (Split-Path $path -Leaf)
+    $icon.ShowBalloonTip(3000, "[$Role] $msg", $first, [System.Windows.Forms.ToolTipIcon]::Info)
+  } catch {}
+}
+
+[System.Windows.Forms.Application]::Run()
+Unregister-Event -SourceIdentifier $handler.Name -ErrorAction SilentlyContinue
+$icon.Visible = $false

--- a/tools/bus.psm1
+++ b/tools/bus.psm1
@@ -1,0 +1,133 @@
+# tools\bus.psm1
+# Minimal file-bus with helpers: Send-Task, Receive-Task, Complete-Task, Send-Event
+
+param()
+
+$script:Roles = "orchestrator","po","architect","backend","frontend","qa","compliance"
+$script:BusRoot = Join-Path $PSScriptRoot "..\bus"
+
+function Initialize-Bus {
+  param([string]$Root = $script:BusRoot)
+  $script:BusRoot = $Root
+  $dirs = "inbox","processing","outbox","archive"
+  foreach ($d in $dirs) {
+    foreach ($r in $script:Roles) {
+      New-Item -ItemType Directory -Force -Path (Join-Path $Root "$d\$r") | Out-Null
+    }
+  }
+  Write-Verbose "Bus ready at $Root"
+  return $Root
+}
+
+function Send-Message {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][ValidateSet("orchestrator","po","architect","backend","frontend","qa","compliance")]$To,
+    [Parameter(Mandatory)][string]$From,
+    [Parameter(Mandatory)][string]$Type,
+    [Parameter(Mandatory)][hashtable]$Payload
+  )
+  $id = [guid]::NewGuid().ToString()
+  $msg = [pscustomobject]@{
+    id=$id; ts=(Get-Date).ToString("o"); to=$To; from=$From; type=$Type; payload=$Payload
+  } | ConvertTo-Json -Depth 20
+  $dir = Join-Path $script:BusRoot "inbox\$To"
+  $tmp = Join-Path $dir "$id.tmp"
+  $fin = Join-Path $dir "$id.json"
+  $msg | Out-File -Encoding utf8 $tmp
+  Rename-Item $tmp $fin
+  return $id
+}
+
+function Receive-Next {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][ValidateSet("orchestrator","po","architect","backend","frontend","qa","compliance")]$Role)
+  $dir = Join-Path $script:BusRoot "inbox\$Role"
+  $file = Get-ChildItem $dir -Filter *.json -ErrorAction SilentlyContinue | Sort-Object LastWriteTime | Select-Object -First 1
+  if (-not $file) { return $null }
+  $procDir = Join-Path $script:BusRoot "processing\$Role"
+  New-Item -ItemType Directory -Force -Path $procDir | Out-Null
+  $claimed = Join-Path $procDir $file.Name
+  try {
+    Move-Item $file.FullName $claimed
+    $obj = Get-Content $claimed -Raw | ConvertFrom-Json
+    $obj | Add-Member NoteProperty _path $claimed
+    $obj | Add-Member NoteProperty _role $Role
+    return $obj
+  } catch { return $null }
+}
+
+function Complete-Message {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][pscustomobject]$Msg,
+    [Parameter(Mandatory)][ValidateSet("ok","fail")]$Status,
+    [string]$ResultText = "",
+    [string]$NotifyTo   # optional: also send a summary event to another role (e.g., "orchestrator")
+  )
+  $role = $Msg.to
+  $name = [IO.Path]::GetFileNameWithoutExtension($Msg._path)
+  $outDir = Join-Path $script:BusRoot "outbox\$role"
+  $arcDir = Join-Path $script:BusRoot "archive\$role"
+  New-Item -ItemType Directory -Force -Path $outDir,$arcDir | Out-Null
+  $resFile = Join-Path $outDir "$name.$Status.txt"
+  "[$((Get-Date).ToString('o'))] $Status`n$ResultText" | Out-File -Encoding utf8 $resFile
+  Move-Item $Msg._path (Join-Path $arcDir "$name.json")
+
+  if ($NotifyTo) {
+    Send-Event -To $NotifyTo -From $role -Name "completed" -Data @{ id = $Msg.id; status = $Status; note = $ResultText }
+  }
+}
+
+# ---------- Friendly helpers (what I was offering) ----------
+
+function Send-Task {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][ValidateSet("orchestrator","po","architect","backend","frontend","qa","compliance")]$To,
+    [Parameter(Mandatory)][string]$From,
+    [Parameter(Mandatory)][string]$Title,
+    [Parameter()][string]$Description = "",
+    [Parameter()][hashtable]$Data = @{}
+  )
+  $payload = @{
+    title = $Title; description = $Description; data = $Data
+  }
+  return Send-Message -To $To -From $From -Type "task" -Payload $payload
+}
+
+function Receive-Task {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][ValidateSet("orchestrator","po","architect","backend","frontend","qa","compliance")]$Role)
+  $m = Receive-Next -Role $Role
+  if (-not $m) { return $null }
+  # expose convenience props
+  $m | Add-Member NoteProperty title       $m.payload.title     -Force
+  $m | Add-Member NoteProperty description $m.payload.description -Force
+  $m | Add-Member NoteProperty data        $m.payload.data      -Force
+  return $m
+}
+
+function Complete-Task {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][pscustomobject]$Task,
+    [Parameter(Mandatory)][ValidateSet("ok","fail")]$Status,
+    [string]$Note = "",
+    [string]$NotifyTo = "orchestrator"
+  )
+  Complete-Message -Msg $Task -Status $Status -ResultText $Note -NotifyTo $NotifyTo
+}
+
+function Send-Event {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][ValidateSet("orchestrator","po","architect","backend","frontend","qa","compliance")]$To,
+    [Parameter(Mandatory)][string]$From,
+    [Parameter(Mandatory)][string]$Name,
+    [Parameter()][hashtable]$Data = @{}
+  )
+  return Send-Message -To $To -From $From -Type "event" -Payload (@{ name=$Name; data=$Data })
+}
+
+Export-ModuleMember -Function Initialize-Bus, Send-Message, Receive-Next, Complete-Message, Send-Task, Receive-Task, Complete-Task, Send-Event


### PR DESCRIPTION
## Summary
- add file-bus PowerShell module with task helpers for offline agent messaging
- add tray notifier script to alert when new bus messages arrive
- document file-bus orchestration for agents

## Testing
- `rg -a --files-with-matches "\u0000" test`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aea45166a8832f9dea34a3c87d2c14