### PR TITLE
docs(stories): shard MVP backlog into individual stories

### DIFF
--- a/docs/stories/1.2-text-extraction.md
+++ b/docs/stories/1.2-text-extraction.md
@@ -14,4 +14,10 @@ notes:
   - Sentence splitting using blingfire.
   - Handle errors gracefully during extraction and persist error state.
 tasks: []
-dev_agent_record: {}
+dev_agent_record:
+  proposed_tasks:
+    - service: Implement extraction using PyMuPDF and docx2python
+    - service: Build sentence index with blingfire
+    - storage: Persist text, page map, and sentence index linked to analysis
+    - config: Add OCR flag in configuration and handle OCR path
+    - tests: Error handling for malformed documents

--- a/docs/stories/1.3-evidence-window-builder.md
+++ b/docs/stories/1.3-evidence-window-builder.md
@@ -13,4 +13,9 @@ notes:
   - Need to handle edge cases like spans near the beginning or end of the document.
   - Configuration for sentence window size should be considered.
 tasks: []
-dev_agent_record: {}
+dev_agent_record:
+  proposed_tasks:
+    - service: Return ±N sentences around a char span using the sentence index
+    - config: Make window size configurable per detector
+    - service: Handle edge cases near document boundaries and page edges
+    - tests: Spans at start, middle, and end of documents

--- a/docs/stories/4.1-metrics-wall.md
+++ b/docs/stories/4.1-metrics-wall.md
@@ -14,4 +14,10 @@ notes:
   - Integration with the token ledger (Story 2.4) for token metrics.
   - Define how latency is measured (e.g., from job queue to completion).
 tasks: []
-dev_agent_record: {}
+dev_agent_record:
+  proposed_tasks:
+    - backend: Instrument API to record p95 latency and tokens_per_doc
+    - backend: Collect %docs_invoking_LLM and explainability rate
+    - backend: Endpoint to aggregate and expose metrics
+    - frontend: Admin-only dashboard to display metrics
+    - tests: Metric collection and role-restricted access

--- a/docs/stories/4.2-coverage-meter.md
+++ b/docs/stories/4.2-coverage-meter.md
@@ -13,4 +13,9 @@ notes:
   - Define what 'coverage' and 'unknown' mean in this context.
   - Visualization could be a simple bar chart or heatmap.
 tasks: []
-dev_agent_record: {}
+dev_agent_record:
+  proposed_tasks:
+    - backend: Compute detector coverage per analysis from findings data
+    - backend: Warn when any detector returns `unknown`
+    - ui: Visual component to display coverage on results or admin page
+    - tests: Coverage calculations and warning display

--- a/docs/stories/5.1-org-settings.md
+++ b/docs/stories/5.1-org-settings.md
@@ -14,4 +14,10 @@ notes:
   - Retention policy defines how long analysis data/files are kept.
   - Audit logging should capture who changed what and when.
 tasks: []
-dev_agent_record: {}
+dev_agent_record:
+  proposed_tasks:
+    - backend: Model and persistence for LLM provider, OCR, and retention policy
+    - api: Endpoints and admin UI to update settings
+    - security: Enforce secure storage with conservative defaults
+    - logging: Audit logging for settings changes
+    - tests: Settings CRUD and security constraints


### PR DESCRIPTION
## Summary
- remove consolidated MVP backlog document
- add proposed implementation shards to individual story files for Text Extraction, Evidence Window Builder, Metrics Wall, Coverage Meter, and Org Settings

## Testing
- `pytest apps/api/blackletter_api/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68af441e064c832fa903c9ae8eecc405