### PR TITLE
feat(api): add stage1 orchestrator and event schemas

### DIFF
--- a/apps/api/blackletter_api/models/schemas.py
+++ b/apps/api/blackletter_api/models/schemas.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Literal, Optional, Tuple
 from uuid import UUID
+from enum import Enum
 
 from pydantic import BaseModel, Field
 
@@ -45,9 +46,19 @@ class VerdictCounts(BaseModel):
     needs_review_count: int = 0
 
 
+class JobState(str, Enum):
+    RECEIVED = "RECEIVED"
+    EXTRACTED = "EXTRACTED"
+    SEGMENTED = "SEGMENTED"
+    GDPR_LEGAL_DONE = "GDPR_LEGAL_DONE"
+    GC_DONE = "GC_DONE"
+    REPORTED = "REPORTED"
+
+
 class AnalysisSummary(BaseModel):
     id: str
     filename: str
     created_at: str
     size: int
     verdicts: VerdictCounts
+    state: JobState

--- a/apps/api/blackletter_api/orchestrator/state.py
+++ b/apps/api/blackletter_api/orchestrator/state.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Dict, List, Optional
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+
+class AnalysisState(str, Enum):
+    """Workflow states for an analysis job."""
+
+    RECEIVED = "RECEIVED"
+    EXTRACTED = "EXTRACTED"
+    SEGMENTED = "SEGMENTED"
+    GDPR_LEGAL_DONE = "GDPR_LEGAL_DONE"
+    GC_DONE = "GC_DONE"
+    REPORTED = "REPORTED"
+
+
+class Analysis(BaseModel):
+    id: str
+    state: AnalysisState
+    gdpr_done: bool = False
+    legal_done: bool = False
+    findings: Dict[str, List[dict]] = {}
+
+
+class Orchestrator:
+    """Simple in-memory orchestrator for the Stage-1 flow."""
+
+    def __init__(self) -> None:
+        self._analyses: Dict[str, Analysis] = {}
+
+    def create(self) -> Analysis:
+        analysis = Analysis(id=str(uuid4()), state=AnalysisState.RECEIVED)
+        self._analyses[analysis.id] = analysis
+        return analysis
+
+    def get(self, analysis_id: str) -> Optional[Analysis]:
+        return self._analyses.get(analysis_id)
+
+    def handle_event(self, analysis_id: str, topic: str, payload: Optional[List[dict]] = None) -> Analysis:
+        analysis = self._analyses[analysis_id]
+        if topic == "document.extracted.v1":
+            analysis.state = AnalysisState.EXTRACTED
+        elif topic == "document.segmented.v1":
+            analysis.state = AnalysisState.SEGMENTED
+        elif topic == "gdpr.findings.ready.v1":
+            analysis.gdpr_done = True
+            analysis.findings["gdpr"] = payload or []
+        elif topic == "legal.findings.ready.v1":
+            analysis.legal_done = True
+            analysis.findings["legal"] = payload or []
+        elif topic == "gc.assessment.ready.v1":
+            analysis.state = AnalysisState.GC_DONE
+            analysis.findings["gc"] = payload or []
+        elif topic == "report.published.v1":
+            analysis.state = AnalysisState.REPORTED
+
+        if analysis.state == AnalysisState.SEGMENTED and analysis.gdpr_done and analysis.legal_done:
+            analysis.state = AnalysisState.GDPR_LEGAL_DONE
+
+        self._analyses[analysis_id] = analysis
+        return analysis
+
+
+orchestrator = Orchestrator()

--- a/apps/api/blackletter_api/routers/analyses.py
+++ b/apps/api/blackletter_api/routers/analyses.py
@@ -1,36 +1,51 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import List
+from typing import Dict, List
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query
 
-from ..models.schemas import AnalysisSummary, Finding, VerdictCounts
+from ..models.schemas import AnalysisSummary, VerdictCounts
+from ..orchestrator.state import orchestrator
 
 
 router = APIRouter(tags=["analyses"])
 
 
-@router.get("/analyses", response_model=List[AnalysisSummary])
-def list_analyses(limit: int = Query(default=50, ge=1, le=200)) -> List[AnalysisSummary]:
-    # MVP scaffold: return an empty list until persistence is implemented.
-    # Later: read from DB and/or filesystem under .data/analyses/...
-    return []
-
-
-@router.get("/analyses/{analysis_id}", response_model=AnalysisSummary)
-def get_analysis_summary(analysis_id: str) -> AnalysisSummary:
-    # Placeholder summary with stable shape for UI wiring
+def _to_summary(analysis) -> AnalysisSummary:
     return AnalysisSummary(
-        id=analysis_id,
+        id=analysis.id,
         filename="placeholder.pdf",
         created_at=datetime.now(timezone.utc).isoformat(),
         size=0,
         verdicts=VerdictCounts(),
+        state=analysis.state,
     )
 
 
-@router.get("/analyses/{analysis_id}/findings", response_model=List[Finding])
-def get_analysis_findings(analysis_id: str) -> List[Finding]:
-    # Placeholder: empty findings array
-    return []
+@router.get("/analyses", response_model=List[AnalysisSummary])
+def list_analyses(limit: int = Query(default=50, ge=1, le=200)) -> List[AnalysisSummary]:
+    analyses = list(orchestrator._analyses.values())[:limit]
+    return [_to_summary(a) for a in analyses]
+
+
+@router.post("/intake", response_model=AnalysisSummary)
+def intake() -> AnalysisSummary:
+    analysis = orchestrator.create()
+    return _to_summary(analysis)
+
+
+@router.get("/analyses/{analysis_id}", response_model=AnalysisSummary)
+def get_analysis_summary(analysis_id: str) -> AnalysisSummary:
+    analysis = orchestrator.get(analysis_id)
+    if not analysis:
+        raise HTTPException(status_code=404, detail="analysis not found")
+    return _to_summary(analysis)
+
+
+@router.get("/analyses/{analysis_id}/findings", response_model=Dict[str, List[dict]])
+def get_analysis_findings(analysis_id: str) -> Dict[str, List[dict]]:
+    analysis = orchestrator.get(analysis_id)
+    if not analysis:
+        raise HTTPException(status_code=404, detail="analysis not found")
+    return analysis.findings

--- a/apps/api/blackletter_api/tests/unit/test_analyses_router.py
+++ b/apps/api/blackletter_api/tests/unit/test_analyses_router.py
@@ -1,12 +1,14 @@
 from fastapi.testclient import TestClient
 
 from blackletter_api.main import app
+from blackletter_api.orchestrator.state import orchestrator
 
 
 client = TestClient(app)
 
 
 def test_list_analyses_empty():
+    orchestrator._analyses.clear()
     res = client.get("/api/analyses?limit=50")
     assert res.status_code == 200
     body = res.json()

--- a/apps/api/blackletter_api/tests/unit/test_stage1_orchestrator.py
+++ b/apps/api/blackletter_api/tests/unit/test_stage1_orchestrator.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+from jsonschema import validate
+
+from blackletter_api.orchestrator.state import AnalysisState, orchestrator
+
+
+def test_event_schema_validation():
+    schema_path = Path(__file__).resolve().parents[5] / "contracts" / "events" / "client.contract.received.v1.schema.json"
+    schema = json.loads(schema_path.read_text())
+    event = {
+        "event_id": "evt-1",
+        "topic": "client.contract.received.v1",
+        "analysis_id": "a1",
+        "payload": {}
+    }
+    validate(instance=event, schema=schema)
+
+
+def test_happy_path_orchestrator():
+    orchestrator._analyses.clear()
+    analysis = orchestrator.create()
+    orchestrator.handle_event(analysis.id, "document.extracted.v1")
+    orchestrator.handle_event(analysis.id, "document.segmented.v1")
+    orchestrator.handle_event(analysis.id, "gdpr.findings.ready.v1", [])
+    orchestrator.handle_event(analysis.id, "legal.findings.ready.v1", [])
+    orchestrator.handle_event(analysis.id, "gc.assessment.ready.v1", [])
+    orchestrator.handle_event(analysis.id, "report.published.v1")
+    assert orchestrator.get(analysis.id).state == AnalysisState.REPORTED

--- a/contracts/events/client.contract.received.v1.schema.json
+++ b/contracts/events/client.contract.received.v1.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "client.contract.received.v1",
+  "type": "object",
+  "required": ["event_id", "topic", "analysis_id", "payload"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "topic": {"const": "client.contract.received.v1"},
+    "analysis_id": {"type": "string"},
+    "payload": {"type": "object"}
+  }
+}

--- a/contracts/events/document.extracted.v1.schema.json
+++ b/contracts/events/document.extracted.v1.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "document.extracted.v1",
+  "type": "object",
+  "required": ["event_id", "topic", "analysis_id", "payload"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "topic": {"const": "document.extracted.v1"},
+    "analysis_id": {"type": "string"},
+    "payload": {"type": "object"}
+  }
+}

--- a/contracts/events/document.segmented.v1.schema.json
+++ b/contracts/events/document.segmented.v1.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "document.segmented.v1",
+  "type": "object",
+  "required": ["event_id", "topic", "analysis_id", "payload"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "topic": {"const": "document.segmented.v1"},
+    "analysis_id": {"type": "string"},
+    "payload": {"type": "object"}
+  }
+}

--- a/contracts/events/envelope.schema.json
+++ b/contracts/events/envelope.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "event-envelope",
+  "type": "object",
+  "required": ["event_id", "topic", "analysis_id", "payload"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "topic": {"type": "string"},
+    "analysis_id": {"type": "string"},
+    "payload": {"type": "object"}
+  }
+}

--- a/contracts/events/gc.assessment.ready.v1.schema.json
+++ b/contracts/events/gc.assessment.ready.v1.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "gc.assessment.ready.v1",
+  "type": "object",
+  "required": ["event_id", "topic", "analysis_id", "payload"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "topic": {"const": "gc.assessment.ready.v1"},
+    "analysis_id": {"type": "string"},
+    "payload": {"type": "object"}
+  }
+}

--- a/contracts/events/gdpr.findings.ready.v1.schema.json
+++ b/contracts/events/gdpr.findings.ready.v1.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "gdpr.findings.ready.v1",
+  "type": "object",
+  "required": ["event_id", "topic", "analysis_id", "payload"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "topic": {"const": "gdpr.findings.ready.v1"},
+    "analysis_id": {"type": "string"},
+    "payload": {"type": "object"}
+  }
+}

--- a/contracts/events/legal.findings.ready.v1.schema.json
+++ b/contracts/events/legal.findings.ready.v1.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "legal.findings.ready.v1",
+  "type": "object",
+  "required": ["event_id", "topic", "analysis_id", "payload"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "topic": {"const": "legal.findings.ready.v1"},
+    "analysis_id": {"type": "string"},
+    "payload": {"type": "object"}
+  }
+}

--- a/contracts/events/report.published.v1.schema.json
+++ b/contracts/events/report.published.v1.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "report.published.v1",
+  "type": "object",
+  "required": ["event_id", "topic", "analysis_id", "payload"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "topic": {"const": "report.published.v1"},
+    "analysis_id": {"type": "string"},
+    "payload": {"type": "object"}
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,3 +72,5 @@ watchfiles==1.1.0
 websockets==15.0.1
 Werkzeug==3.1.3
 wheel==0.45.1
+
+jsonschema==4.23.0


### PR DESCRIPTION
## Summary
- add in-memory Stage-1 orchestrator with event-driven state machine
- expose `/api/intake` and analysis inspection endpoints
- define JSON schemas for Stage-1 topics

## Testing
- `pytest apps/api/blackletter_api/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4f021aec832fa5d01c4c53445b15