### PR TITLE
chore(web): Fix linting, tests, and dependencies for Story 0.0

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -12,6 +12,12 @@ const compat = new FlatCompat({
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
   {
+    files: ["**/*.js"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
+  {
     ignores: [
       "node_modules/**",
       ".next/**",

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -10,6 +10,12 @@ const config = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
+  testPathIgnorePatterns: [
+    "<rootDir>/node_modules/",
+    "<rootDir>/.next/",
+    "<rootDir>/tests/e2e/",
+    "<rootDir>/tests/a11y/",
+  ],
 };
 
 module.exports = createJestConfig(config);

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.44.0",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.4.5",
         "@testing-library/react": "^16.0.0",
@@ -2165,6 +2166,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -9161,6 +9178,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "framer-motion": "^11.3.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.44.0",
     "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/apps/web/src/app/new/page.tsx
+++ b/apps/web/src/app/new/page.tsx
@@ -31,8 +31,6 @@ export default function NewUploadPage() {
   const [running, setRunning] = useState(false);
   const [canceled, setCanceled] = useState(false);
   const timerRef = useRef<number | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [jobId, setJobId] = useState<string | null>(null);
   const lastAnalysisId = useRef<string | null>(null);
   const router = useRouter();
 
@@ -46,12 +44,9 @@ export default function NewUploadPage() {
     setStepIndex(0);
     setCanceled(false);
     setRunning(true);
-    setError(null);
-    setJobId(null);
     lastAnalysisId.current = null;
     if (!mockMode) {
-      startRealUpload(f).catch((e) => {
-        setError(e instanceof Error ? e.message : String(e));
+      startRealUpload(f).catch(() => {
         setRunning(false);
       });
     }
@@ -60,7 +55,6 @@ export default function NewUploadPage() {
   const startRealUpload = async (f: File) => {
     // 1) Upload
     const init = await uploadContract(f);
-    setJobId(init.id);
     if (init.analysis_id) lastAnalysisId.current = init.analysis_id;
     // queued
     setStepIndex(0);
@@ -79,7 +73,6 @@ export default function NewUploadPage() {
         done = true;
         break;
       } else if (j.status === "error") {
-        setError(j.error_reason || "job_error");
         setRunning(false);
         done = true;
         break;
@@ -95,7 +88,6 @@ export default function NewUploadPage() {
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Advance state machine on a timer when running (mock mode only)
@@ -127,8 +119,6 @@ export default function NewUploadPage() {
     setStepIndex(0);
     setCanceled(false);
     setRunning(false);
-    setError(null);
-    setJobId(null);
     lastAnalysisId.current = null;
   }
 

--- a/apps/web/src/lib/mocks.ts
+++ b/apps/web/src/lib/mocks.ts
@@ -62,7 +62,7 @@ export function getMockAnalysisSummary(id: string): AnalysisSummary {
 
 export function getMockFindings(id: string): Finding[] {
   const rng = seededRandom(hashStringToSeed(id) + 7);
-  return DETECTORS.map((det, idx) => {
+  return DETECTORS.map((det) => {
     const v = VERDICT_ORDER[Math.floor(rng() * VERDICT_ORDER.length)];
     const start = Math.floor(rng() * 2000);
     const end = start + Math.floor(120 + rng() * 200);

--- a/apps/web/test/setup-jest.ts
+++ b/apps/web/test/setup-jest.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 
 // Helpful no-ops for JSDOM environment
-// @ts-ignore
+// @ts-expect-error JSDOM doesn't implement scrollIntoView
 window.HTMLElement.prototype.scrollIntoView = function () {};
 

--- a/apps/web/test/setup.ts
+++ b/apps/web/test/setup.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 
 // Helpful no-ops for JSDOM environment
-// @ts-ignore
+// @ts-expect-error JSDOM doesn't implement scrollIntoView
 window.HTMLElement.prototype.scrollIntoView = function () {};
 

--- a/docs/stories/0.0-demo-mock-contract-flow.md
+++ b/docs/stories/0.0-demo-mock-contract-flow.md
@@ -121,17 +121,22 @@
  - fix(web): type verdict select change; satisfy eslint
  - test(web): add RTL/Jest a11y tests for demo flow (dialog, drawer, table, chips)
  - fix(web): add aria-labelledby on dialog/drawer for accessible names
+- chore(web): fix lint errors and missing test dependencies
 
 **completion_notes**
 
 - Flow validated Dashboard -> Findings -> Export -> Reports using mocks.
  - A11y unit tests added and passing (Jest + RTL).
  - Lint: npm run lint now passes with 0 errors (2 warnings remain: unused directive in new/page.tsx and unused var in mocks.ts).
+- Installed missing `@playwright/test` dependency to fix test runner errors.
+- Fixed all linting errors and warnings for a clean build.
+- Configured Jest to ignore e2e and a11y test directories.
 
 **debug_log**
 
 - Ran: `npm run lint` in `apps/web` -> fixed errors by extracting client components and updating types/links.
  - Ran: `npm run test` in `apps/web` -> 4 suites, 5 tests passing.
+- Ran `npm run lint` and `npm run test` in `apps/web` -> all checks pass.
 
 **decisions**
 


### PR DESCRIPTION
This commit addresses several issues found during the verification of Story 0.0. It cleans up the `apps/web` package to ensure a stable baseline for future development.

Key changes:
- Added the missing `@playwright/test` dev dependency to fix test discovery errors.
- Configured Jest's `testPathIgnorePatterns` to exclude Playwright e2e tests, ensuring `npm run test` only runs unit/component tests.
- Fixed all ESLint errors and warnings by updating the ESLint config, replacing `@ts-ignore` with descriptive `@ts-expect-error` directives, and removing unused code.
- Updated the `dev_agent_record` in Story 0.0 to accurately reflect these cleanup changes.