### PR TITLE
test(api): add config and route unit tests

### DIFF
--- a/apps/api/blackletter_api/tests/unit/test_core_config_loader.py
+++ b/apps/api/blackletter_api/tests/unit/test_core_config_loader.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from blackletter_api.core_config_loader import CoreConfig, load_core_config
+
+
+def test_load_core_config_defaults_when_missing(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "missing.yaml"
+    cfg = load_core_config(str(cfg_path))
+    assert cfg == CoreConfig()
+
+
+def test_load_core_config_from_file(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "core-config.yaml"
+    cfg_path.write_text("evidence_window_sentences: 5\nenable_weak_language: false\n", encoding="utf-8")
+    cfg = load_core_config(str(cfg_path))
+    assert cfg.evidence_window_sentences == 5
+    assert cfg.enable_weak_language is False
+
+
+def test_load_core_config_malformed_yaml_returns_defaults(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "core-config.yaml"
+    cfg_path.write_text("::bad_yaml::", encoding="utf-8")
+    cfg = load_core_config(str(cfg_path))
+    assert cfg == CoreConfig()
+
+
+def test_load_core_config_uses_default_path(monkeypatch, tmp_path: Path) -> None:
+    cfg_path = tmp_path / "core-config.yaml"
+    cfg_path.write_text("evidence_window_sentences: 7\nenable_weak_language: true\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    cfg = load_core_config()
+    assert cfg.evidence_window_sentences == 7
+    assert cfg.enable_weak_language is True

--- a/apps/api/blackletter_api/tests/unit/test_main.py
+++ b/apps/api/blackletter_api/tests/unit/test_main.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from blackletter_api.main import app
+
+
+client = TestClient(app)
+
+
+def test_read_root() -> None:
+    res = client.get("/")
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok"}
+
+
+def test_healthz() -> None:
+    res = client.get("/healthz")
+    assert res.status_code == 200
+    assert res.json() == {"ok": True}

--- a/apps/api/blackletter_api/tests/unit/test_rules_router.py
+++ b/apps/api/blackletter_api/tests/unit/test_rules_router.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from blackletter_api.main import app
+from blackletter_api.services.rulepack_loader import RulepackError
+
+
+client = TestClient(app)
+
+
+def test_rules_summary_handles_loader_error(monkeypatch) -> None:
+    def _raise(*args, **kwargs):  # type: ignore[unused-arg]
+        raise RulepackError("boom")
+
+    monkeypatch.setattr("blackletter_api.routers.rules.load_rulepack", _raise)
+    res = client.get("/api/rules/summary")
+    assert res.status_code == 500
+    assert res.json()["detail"] == "Rulepack error: boom"


### PR DESCRIPTION
## Summary
- add unit tests for core configuration loader
- cover root and health endpoints
- verify rules summary error handling

## Testing
- `pytest apps/api/blackletter_api/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4448c8c8832fbb25f9925f170eaf