### PR TITLE
feat(api): add logging to core config loader

### DIFF
--- a/apps/api/blackletter_api/tests/unit/test_core_config_loader.py
+++ b/apps/api/blackletter_api/tests/unit/test_core_config_loader.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+
+from blackletter_api.core_config_loader import CoreConfig, load_core_config
+
+
+def test_load_core_config_logs_and_defaults_on_bad_yaml(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    cfg_file = tmp_path / "core-config.yaml"
+    cfg_file.write_text("invalid: [\n")
+    with caplog.at_level(logging.WARNING):
+        cfg = load_core_config(str(cfg_file))
+    assert cfg == CoreConfig()
+    assert any("Failed to load core config" in record.message for record in caplog.records)
+
+
+def test_load_core_config_raises_when_required_and_missing(tmp_path: Path) -> None:
+    missing_file = tmp_path / "nope.yaml"
+    with pytest.raises(FileNotFoundError):
+        load_core_config(str(missing_file), required=True)
+
+
+def test_load_core_config_raises_when_required_on_error(tmp_path: Path) -> None:
+    cfg_file = tmp_path / "core-config.yaml"
+    cfg_file.write_text("evidence_window_sentences: [1, 2\n")
+    with pytest.raises(yaml.YAMLError):
+        load_core_config(str(cfg_file), required=True)


### PR DESCRIPTION
## Summary
- log missing or malformed core-config and allow required load
- add tests for `load_core_config`

## Testing
- `pytest apps/api/blackletter_api/tests/unit/test_core_config_loader.py -q`
- `pytest apps/api/blackletter_api/tests -q` *(fails: ImportError: cannot import name 'get_analysis_text')*

------
https://chatgpt.com/codex/tasks/task_e_68b3219a3fd0832f949e7191fc675de8