### PR TITLE
feat(api): add document QA endpoint skeleton

### DIFF
--- a/apps/api/blackletter_api/main.py
+++ b/apps/api/blackletter_api/main.py
@@ -11,6 +11,7 @@ from .routers import rules, analyses
 from .routers import contracts, jobs, reports
 from .routers import risk_analysis, admin
 from .routers import orchestration, gemini
+from .routers import document_qa
 
 # Create the database tables
 entities.Base.metadata.create_all(bind=engine)
@@ -98,6 +99,7 @@ app.include_router(risk_analysis.router, prefix="/api")
 app.include_router(admin.router)
 app.include_router(orchestration.router)
 app.include_router(gemini.router, prefix="/api")
+app.include_router(document_qa.router, prefix="/api")
 
 
 @app.get("/")

--- a/apps/api/blackletter_api/models/schemas.py
+++ b/apps/api/blackletter_api/models/schemas.py
@@ -117,3 +117,15 @@ class RulesSummary(BaseModel):
     detector_count: int
     detectors: List[DetectorSummary]
     lexicons: List[str]
+
+
+class QASource(BaseModel):
+    """Source citation for a Q&A response."""
+    page: int
+    content: str
+
+
+class QAResponse(BaseModel):
+    """Answer returned from the document Q&A endpoint."""
+    answer: str
+    sources: List[QASource] = Field(default_factory=list)

--- a/apps/api/blackletter_api/routers/document_qa.py
+++ b/apps/api/blackletter_api/routers/document_qa.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+from typing import List, Optional
+
+from ..services.document_qa import DocumentQAService
+from ..models.schemas import QAResponse
+
+
+class QuestionRequest(BaseModel):
+    question: str
+    chat_history: Optional[List[str]] = None
+    mode: Optional[str] = "simple"
+
+
+router = APIRouter(tags=["qa"])
+service = DocumentQAService()
+
+
+@router.post("/documents/{document_id}/qa", response_model=QAResponse)
+async def document_question_answer(
+    document_id: str, payload: QuestionRequest
+) -> QAResponse:
+    """Answer a question about a specific document using RAG."""
+    mode = payload.mode or "simple"
+    if mode == "citations":
+        return await service.answer_with_citations(document_id, payload.question)
+    if mode == "conversational":
+        return await service.answer_with_history(
+            document_id, payload.question, payload.chat_history
+        )
+    if mode == "hybrid":
+        return await service.answer_hybrid(
+            document_id, payload.question, payload.chat_history
+        )
+    # default simple
+    return await service.answer_simple(document_id, payload.question)

--- a/apps/api/blackletter_api/services/document_qa.py
+++ b/apps/api/blackletter_api/services/document_qa.py
@@ -1,0 +1,59 @@
+"""Document question-answering service.
+
+Provides multiple retrieval-augmented generation strategies for answering
+questions about specific documents. The implementations here are minimal
+placeholders that demonstrate the API surface for the four versions described
+in the design notes:
+
+1. Simple RAG
+2. RAG with citations
+3. Conversational RAG with chat history
+4. Hybrid semantic/keyword search
+"""
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+
+from ..models.schemas import (
+    QAResponse,
+    QASource,
+)
+
+
+class DocumentQAService:
+    """Service for answering questions about uploaded documents.
+
+    The methods currently return placeholder responses. Real implementations
+    should integrate a vector store and large language model.
+    """
+
+    async def answer_simple(self, document_id: str, question: str) -> QAResponse:
+        """Version 1: basic retrieval augmented generation."""
+        return QAResponse(answer="This is a placeholder answer.", sources=[])
+
+    async def answer_with_citations(
+        self, document_id: str, question: str
+    ) -> QAResponse:
+        """Version 2: RAG with source citation."""
+        source = QASource(page=1, content="Example excerpt")
+        return QAResponse(answer="Placeholder answer with citation.", sources=[source])
+
+    async def answer_with_history(
+        self,
+        document_id: str,
+        question: str,
+        chat_history: Optional[Iterable[str]] = None,
+    ) -> QAResponse:
+        """Version 3: conversational RAG using chat history."""
+        _ = chat_history  # For future use
+        return QAResponse(answer="Placeholder conversational answer.", sources=[])
+
+    async def answer_hybrid(
+        self,
+        document_id: str,
+        question: str,
+        chat_history: Optional[Iterable[str]] = None,
+    ) -> QAResponse:
+        """Version 4: hybrid search (semantic + keyword)."""
+        _ = chat_history  # For future use
+        return QAResponse(answer="Placeholder hybrid answer.", sources=[])

--- a/apps/api/blackletter_api/services/storage.py
+++ b/apps/api/blackletter_api/services/storage.py
@@ -134,3 +134,13 @@ def list_analyses_summaries(limit: int = 50) -> List[AnalysisSummary]:
     # Sort by created_at desc if available
     items.sort(key=lambda x: _parse_iso(x.created_at), reverse=True)
     return items[: max(0, int(limit))]
+
+
+def get_analysis_text(analysis_id: str) -> str:
+    """Placeholder retrieval of analysis text."""
+    return ""
+
+
+def get_analysis_findings(analysis_id: str) -> list:
+    """Placeholder retrieval of analysis findings."""
+    return []

--- a/apps/api/blackletter_api/tests/unit/test_document_qa_router.py
+++ b/apps/api/blackletter_api/tests/unit/test_document_qa_router.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+
+from blackletter_api.main import app
+
+client = TestClient(app)
+
+
+def test_document_qa_simple() -> None:
+    res = client.post(
+        "/api/documents/doc-1/qa",
+        json={"question": "What is the purpose?"},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["answer"]
+    assert data["sources"] == []


### PR DESCRIPTION
## Summary
- add placeholder Document QA service with multiple RAG strategies
- expose new `/api/documents/{document_id}/qa` endpoint
- define QA response models and basic test

## Testing
- `pytest apps/api/blackletter_api/tests/unit/test_document_qa_router.py -q` *(fails: TypeError: non-default argument 'last_activity' follows default argument)*

------
https://chatgpt.com/codex/tasks/task_e_68b3247a506c832f97e4577d25d381e9