### PR TITLE
feat(web): fetch analyses from API without mocks

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,31 +1,8 @@
 import { getAnalyses } from "@/lib/api";
-import { getMockAnalyses } from "@/lib/mocks";
 import DemoBanner from "@/components/DemoBanner";
-import VerdictBadge from "@/components/VerdictBadge";
-import type { AnalysisSummary } from "@/lib/types";
-
-async function fetchAnalyses(): Promise<AnalysisSummary[]> {
-  try {
-    // Try to fetch from real API first
-    return await getAnalyses(50);
-  } catch (error) {
-    console.warn("Failed to fetch from API, falling back to mocks:", error);
-    // Fallback to mocks if API is not available
-    const items = getMockAnalyses(10);
-    // Ensure the first item is ACME_DPA_MOCK.pdf with id mock-1
-    if (items.length) {
-      items[0] = {
-        ...items[0],
-        id: "mock-1",
-        filename: "ACME_DPA_MOCK.pdf",
-      };
-    }
-    return items;
-  }
-}
 
 export default async function DashboardPage() {
-  const analyses = await fetchAnalyses();
+  const analyses = await getAnalyses(10);
 
   if (!analyses.length) {
     return (

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -45,9 +45,9 @@ export async function getJob(jobId: string): Promise<JobStatusDto> {
   } as JobStatusDto;
 }
 
-export async function getAnalyses(limit = 50): Promise<AnalysisSummary[]> {
+export async function getAnalyses(limit: number): Promise<AnalysisSummary[]> {
   const res = await fetch(`${apiBase()}/api/analyses?limit=${limit}`, {
-    cache: "no-store"
+    cache: "no-store",
   });
   if (!res.ok) {
     const detail = await safeDetail(res);


### PR DESCRIPTION
## Summary
- fetch recent analyses via `/api/analyses?limit=` endpoint
- render dashboard using API results and remove mock fallbacks

## Testing
- `cd apps/web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b31db61b64832fb45679f4b038f566