### PR TITLE
feat(auth): add login endpoint and page

### DIFF
--- a/apps/api/blackletter_api/auth.py
+++ b/apps/api/blackletter_api/auth.py
@@ -1,0 +1,24 @@
+"""Simple authentication utilities for the Blackletter API."""
+import os
+from datetime import datetime, timedelta
+from typing import Dict
+
+import jwt
+
+# Demo in-memory user store
+_USER_DB: Dict[str, str] = {"user@example.com": "strongPassword"}
+
+SECRET_KEY = os.getenv("JWT_SECRET_KEY", "change-me")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+def authenticate_user(username: str, password: str) -> bool:
+    """Validate a user's credentials against the in-memory store."""
+    expected = _USER_DB.get(username)
+    return expected is not None and expected == password
+
+def create_access_token(username: str) -> str:
+    """Create a signed JWT access token for a given username."""
+    expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    payload = {"sub": username, "exp": expire}
+    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)

--- a/apps/api/blackletter_api/auth_app.py
+++ b/apps/api/blackletter_api/auth_app.py
@@ -1,0 +1,8 @@
+"""Minimal FastAPI app exposing only the auth routes.
+Useful for lightweight testing and demos."""
+from fastapi import FastAPI
+
+from .routers import auth
+
+app = FastAPI()
+app.include_router(auth.router)

--- a/apps/api/blackletter_api/main.py
+++ b/apps/api/blackletter_api/main.py
@@ -10,7 +10,7 @@ from .models import entities
 from .routers import rules, analyses
 from .routers import contracts, jobs, reports
 from .routers import risk_analysis, admin
-from .routers import orchestration, gemini
+from .routers import orchestration, gemini, auth
 
 # Create the database tables
 entities.Base.metadata.create_all(bind=engine)
@@ -98,6 +98,7 @@ app.include_router(risk_analysis.router, prefix="/api")
 app.include_router(admin.router)
 app.include_router(orchestration.router)
 app.include_router(gemini.router, prefix="/api")
+app.include_router(auth.router)
 
 
 @app.get("/")

--- a/apps/api/blackletter_api/routers/auth.py
+++ b/apps/api/blackletter_api/routers/auth.py
@@ -1,0 +1,21 @@
+"""Authentication routes for the Blackletter API."""
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..auth import authenticate_user, create_access_token
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+@router.post("/login")
+def login(req: LoginRequest):
+    """Authenticate a user and return a JWT access token."""
+    if not authenticate_user(req.username, req.password):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = create_access_token(req.username)
+    return {"access_token": token}

--- a/apps/api/blackletter_api/tests/integration/test_auth.py
+++ b/apps/api/blackletter_api/tests/integration/test_auth.py
@@ -1,0 +1,27 @@
+"""Integration tests for authentication endpoints."""
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+
+from apps.api.blackletter_api.routers import auth
+
+app = FastAPI()
+app.include_router(auth.router)
+client = TestClient(app)
+
+
+def test_login_success() -> None:
+    response = client.post(
+        "/api/auth/login",
+        json={"username": "user@example.com", "password": "strongPassword"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data and data["access_token"]
+
+
+def test_login_failure() -> None:
+    response = client.post(
+        "/api/auth/login",
+        json={"username": "user@example.com", "password": "bad"},
+    )
+    assert response.status_code == 401

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState, ChangeEvent, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [form, setForm] = useState({ username: '', password: '' });
+  const [error, setError] = useState('');
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+      const res = await fetch(`${apiUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) {
+        throw new Error('Invalid credentials');
+      }
+      const data = await res.json();
+      localStorage.setItem('access_token', data.access_token);
+      router.push('/dashboard');
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        <h1 className="text-2xl font-semibold text-center">Login</h1>
+        {error && (
+          <p className="text-sm text-red-600 text-center" data-testid="error">
+            {error}
+          </p>
+        )}
+        <input
+          type="email"
+          name="username"
+          placeholder="Email"
+          value={form.username}
+          onChange={handleChange}
+          className="w-full border rounded px-3 py-2"
+        />
+        <input
+          type="password"
+          name="password"
+          placeholder="Password"
+          value={form.password}
+          onChange={handleChange}
+          className="w-full border rounded px-3 py-2"
+        />
+        <button
+          type="submit"
+          className="w-full bg-black text-white rounded py-2 hover:opacity-90"
+        >
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/tests/e2e/login-flow.spec.ts
+++ b/apps/web/tests/e2e/login-flow.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test('user logs in and is redirected to dashboard', async ({ page }) => {
+  await page.goto('/login');
+  await page.fill('input[name="username"]', 'user@example.com');
+  await page.fill('input[name="password"]', 'strongPassword');
+  await page.click('button[type="submit"]');
+  await page.waitForURL('**/dashboard');
+  const token = await page.evaluate(() => localStorage.getItem('access_token'));
+  expect(token).toBeTruthy();
+});

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ pillow==11.3.1
 pydantic==2.11.7
 pydantic_core==2.33.2
 pydub==0.25.1
+PyJWT==2.9.0
 Pygments==2.19.2
 PyMuPDF==1.26.3
 pyrsistent==0.20.0


### PR DESCRIPTION
## Summary
- add JWT auth utilities and `/api/auth/login` route
- create Next.js login page using API URL env
- cover auth flow with FastAPI and Playwright tests

## Testing
- `pytest apps/api/blackletter_api/tests/integration/test_auth.py -q`
- `npm test`
- `PLAYWRIGHT_BASE_URL=http://localhost:3001 npx -y playwright@1.44.0 test tests/e2e/login-flow.spec.ts` *(fails: No tests found due to version conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68b31a853dc8832f871374ffb9707845