### PR TITLE
feat(api): implement keyword-based document chunk search

### DIFF
--- a/apps/api/blackletter_api/models/__init__.py
+++ b/apps/api/blackletter_api/models/__init__.py
@@ -1,1 +1,3 @@
+from .chunk import DocumentChunk
 
+__all__ = ["DocumentChunk"]

--- a/apps/api/blackletter_api/models/chunk.py
+++ b/apps/api/blackletter_api/models/chunk.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from sqlalchemy import Column, Integer, Text
+
+from ..database import Base
+
+
+class DocumentChunk(Base):
+    """Persistence model for document text chunks."""
+
+    __tablename__ = "document_chunks"
+
+    id = Column(Integer, primary_key=True)
+    content = Column(Text, nullable=False)

--- a/apps/api/blackletter_api/services/chunk_search.py
+++ b/apps/api/blackletter_api/services/chunk_search.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from sqlalchemy import bindparam, or_, select
+from sqlalchemy.orm import Session
+
+from ..models import DocumentChunk
+
+
+def search_chunks(db: Session, keywords: Iterable[str]) -> List[DocumentChunk]:
+    """Return chunks whose content matches any of the given keywords.
+
+    Keyword comparison is case-insensitive and safely parameter bound.
+    """
+    tokens = [kw for kw in keywords if kw]
+    stmt = select(DocumentChunk)
+    if not tokens:
+        return list(db.execute(stmt).scalars())
+
+    params = {}
+    clauses = []
+    for idx, kw in enumerate(tokens):
+        param = f"kw_{idx}"
+        clauses.append(DocumentChunk.content.ilike(bindparam(param)))
+        params[param] = f"%{kw}%"
+
+    stmt = stmt.where(or_(*clauses))
+    return list(db.execute(stmt, params).scalars())

--- a/apps/api/blackletter_api/tests/unit/test_chunk_search.py
+++ b/apps/api/blackletter_api/tests/unit/test_chunk_search.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from blackletter_api.database import Base
+from blackletter_api.models import DocumentChunk
+from blackletter_api.services.chunk_search import search_chunks
+
+
+@pytest.fixture()
+def db_session() -> Session:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    with SessionLocal() as session:
+        session.add_all(
+            [
+                DocumentChunk(content="The quick brown fox"),
+                DocumentChunk(content="Lazy Dog leaps over"),
+                DocumentChunk(content="Something unrelated"),
+            ]
+        )
+        session.commit()
+        yield session
+
+
+def test_search_chunks_matches_keywords(db_session: Session) -> None:
+    results = search_chunks(db_session, ["fox", "dog"])
+    contents = {chunk.content for chunk in results}
+    assert contents == {"The quick brown fox", "Lazy Dog leaps over"}
+
+
+def test_search_chunks_handles_empty_keywords(db_session: Session) -> None:
+    results = search_chunks(db_session, [])
+    assert len(results) == 3


### PR DESCRIPTION
## Summary
- add `DocumentChunk` model for storing text chunks
- implement `search_chunks` using SQLAlchemy `select`, `or_`, and `ilike`
- test keyword search including empty keyword edge case

## Testing
- `pytest apps/api/blackletter_api/tests/unit/test_chunk_search.py -q`
- `pytest apps/api/blackletter_api/tests -q` *(fails: ModuleNotFoundError: No module named 'watchdog')*


------
https://chatgpt.com/codex/tasks/task_e_68b32a7c4120832f927f9f8d2c83d5cf