### PR TITLE
test(api): cover document QA service and API route

### DIFF
--- a/apps/api/blackletter_api/routers/document_qa.py
+++ b/apps/api/blackletter_api/routers/document_qa.py
@@ -36,3 +36,11 @@ async def document_question_answer(
         )
     # default simple
     return await service.answer_simple(document_id, payload.question)
+
+
+@router.post("/qa/{document_id}", response_model=QAResponse)
+async def question_answer(
+    document_id: str, payload: QuestionRequest
+) -> QAResponse:
+    """Alias route for document question-answering."""
+    return await document_question_answer(document_id, payload)

--- a/apps/api/blackletter_api/tests/integration/test_qa_endpoint.py
+++ b/apps/api/blackletter_api/tests/integration/test_qa_endpoint.py
@@ -1,0 +1,37 @@
+"""Integration tests for /api/qa/{document_id} route."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from blackletter_api.routers.document_qa import router as qa_router
+
+
+app = FastAPI()
+app.include_router(qa_router, prefix="/api")
+client = TestClient(app)
+
+
+def test_qa_route_simple_mode() -> None:
+    """Default QA route should return an answer with no sources."""
+    resp = client.post(
+        "/api/qa/doc-1",
+        json={"question": "What is the purpose?"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["answer"]
+    assert data["sources"] == []
+
+
+def test_qa_route_citations_mode() -> None:
+    """QA route in citation mode should include source details."""
+    resp = client.post(
+        "/api/qa/doc-1",
+        json={"question": "What is the purpose?", "mode": "citations"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["answer"]
+    assert isinstance(data["sources"], list)
+    assert data["sources"][0]["page"] == 1
+

--- a/apps/api/blackletter_api/tests/unit/test_document_qa_service.py
+++ b/apps/api/blackletter_api/tests/unit/test_document_qa_service.py
@@ -1,0 +1,84 @@
+"""Unit tests for DocumentQAService answer methods."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ...services.document_qa import DocumentQAService
+from ...models.schemas import QASource
+
+
+@pytest.mark.asyncio
+async def test_answer_simple_uses_placeholders() -> None:
+    """Ensure simple RAG returns placeholder answer without sources."""
+    service = DocumentQAService()
+    service.embedding = MagicMock()
+    service.db = MagicMock()
+    service.llm = MagicMock()
+
+    result = await service.answer_simple("doc-1", "What is this?")
+
+    assert result.answer == "This is a placeholder answer."
+    assert result.sources == []
+    service.embedding.assert_not_called()
+    service.db.assert_not_called()
+    service.llm.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_answer_with_citations_returns_source() -> None:
+    """RAG with citations should include a source entry."""
+    service = DocumentQAService()
+    service.embedding = MagicMock()
+    service.db = MagicMock()
+    service.llm = MagicMock()
+
+    result = await service.answer_with_citations("doc-1", "Question?")
+
+    assert result.answer == "Placeholder answer with citation."
+    assert len(result.sources) == 1
+    assert isinstance(result.sources[0], QASource)
+    service.embedding.assert_not_called()
+    service.db.assert_not_called()
+    service.llm.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_answer_with_history_returns_placeholder() -> None:
+    """Conversational RAG should accept chat history and return answer."""
+    service = DocumentQAService()
+    service.embedding = MagicMock()
+    service.db = MagicMock()
+    service.llm = MagicMock()
+
+    result = await service.answer_with_history(
+        "doc-1", "Question?", chat_history=["hi"]
+    )
+
+    assert result.answer == "Placeholder conversational answer."
+    assert result.sources == []
+    service.embedding.assert_not_called()
+    service.db.assert_not_called()
+    service.llm.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_answer_hybrid_returns_placeholder() -> None:
+    """Hybrid search should return placeholder answer."""
+    service = DocumentQAService()
+    service.embedding = MagicMock()
+    service.db = MagicMock()
+    service.llm = MagicMock()
+
+    result = await service.answer_hybrid(
+        "doc-1", "Question?", chat_history=["hi"]
+    )
+
+    assert result.answer == "Placeholder hybrid answer."
+    assert result.sources == []
+    service.embedding.assert_not_called()
+    service.db.assert_not_called()
+    service.llm.assert_not_called()
+


### PR DESCRIPTION
## Summary
- add alias `/api/qa/{document_id}` endpoint for document QA
- add unit tests for DocumentQAService answer methods using mocks
- add integration tests for `/api/qa/{document_id}` routing and response

## Testing
- `pytest apps/api/blackletter_api/tests/unit/test_document_qa_service.py -q`
- `pytest apps/api/blackletter_api/tests/integration/test_qa_endpoint.py -q`
- `pytest apps/api/blackletter_api/tests -q` *(fails: non-default argument 'last_activity' follows default argument)*

------
https://chatgpt.com/codex/tasks/task_e_68b32dea9c94832fb48c9cf96bcad689