### PR TITLE
feat(api): include qa router

### DIFF
--- a/apps/api/blackletter_api/main.py
+++ b/apps/api/blackletter_api/main.py
@@ -11,7 +11,7 @@ from .routers import rules, analyses
 from .routers import contracts, jobs, reports
 from .routers import risk_analysis, admin
 from .routers import orchestration, gemini
-from .routers import document_qa
+from .routers import document_qa, qa
 
 # Create the database tables
 entities.Base.metadata.create_all(bind=engine)
@@ -100,6 +100,7 @@ app.include_router(admin.router)
 app.include_router(orchestration.router)
 app.include_router(gemini.router, prefix="/api")
 app.include_router(document_qa.router, prefix="/api")
+app.include_router(qa.router, prefix="/api")
 
 
 @app.get("/")

--- a/apps/api/blackletter_api/routers/qa.py
+++ b/apps/api/blackletter_api/routers/qa.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+router = APIRouter(tags=["qa"])
+
+
+@router.get("/qa/status")
+async def qa_status() -> dict[str, str]:
+    """Check QA router status."""
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- import new qa router and expose it under `/api`
- add basic QA status endpoint

## Testing
- `pytest apps/api/blackletter_api/tests -q` *(fails: TypeError non-default argument 'last_activity' follows default argument)*

------
https://chatgpt.com/codex/tasks/task_e_68b32dd0295c832fab69dab2e2aef2bd