### PR TITLE
fix(web): support windows for playwright dev server

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from '@playwright/test';
+import path from 'path';
+
+const runDev = process.platform === 'win32' ? 'npm.cmd run dev' : 'npm run dev';
 
 export default defineConfig({
   testDir: './tests',
@@ -8,5 +11,13 @@ export default defineConfig({
     baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000',
     headless: true,
   },
+  webServer: [
+    {
+      command: runDev,
+      cwd: path.join(process.cwd(), 'apps/web'),
+      port: 3000,
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
 });
 


### PR DESCRIPTION
## Summary
- detect Windows when starting Playwright's dev server and run `npm.cmd`
- start web server for tests from the `apps/web` directory

## Testing
- `node -e "const cmd = process.platform === 'win32' ? 'npm.cmd run dev' : 'npm run dev'; console.log('platform', process.platform, 'command', cmd)"`
- `node -e "const platform='win32'; const cmd = platform==='win32'? 'npm.cmd run dev':'npm run dev'; console.log('platform', platform, 'command', cmd)"`
- `./apps/web/node_modules/.bin/playwright test -c apps/web/playwright.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b32f1eebec832f9fa3aebd1152be73