### PR TITLE
feat(qa): inject embedding and LLM clients

### DIFF
--- a/apps/api/blackletter_api/services/document_qa.py
+++ b/apps/api/blackletter_api/services/document_qa.py
@@ -12,24 +12,74 @@ in the design notes:
 """
 from __future__ import annotations
 
-from typing import Iterable, List, Optional
+from typing import Callable, Iterable, List, Optional
 
 from ..models.schemas import (
     QAResponse,
     QASource,
 )
+from .gemini_service import gemini_service
 
 
 class DocumentQAService:
     """Service for answering questions about uploaded documents.
 
-    The methods currently return placeholder responses. Real implementations
-    should integrate a vector store and large language model.
+    The service uses dependency-injected embedding and LLM callables so the
+    implementation can be easily swapped for tests. If not provided, sensible
+    defaults are used:
+
+    * ``embed_fn`` – uses a small sentence-transformer via LangChain
+    * ``llm_fn`` – calls the configured :class:`GeminiService` client
     """
 
+    def __init__(
+        self,
+        embed_fn: Callable[[str], List[float]] | None = None,
+        llm_fn: Callable[[str], str] | None = None,
+    ) -> None:
+        self._embed = embed_fn or self._default_embed
+        self._call_llm = llm_fn or self._default_call_llm
+
+    # ------------------------------------------------------------------
+    # Default dependency implementations
+    # ------------------------------------------------------------------
+    def _default_embed(self, text: str) -> List[float]:
+        """Generate an embedding for ``text`` using LangChain.
+
+        The model is instantiated lazily so tests can inject a cheap stub
+        without pulling heavy weights.
+        """
+
+        try:
+            from langchain.embeddings import HuggingFaceEmbeddings
+        except Exception:  # pragma: no cover - optional dependency
+            return [0.0]
+
+        if not hasattr(self, "_embedder"):
+            self._embedder = HuggingFaceEmbeddings(
+                model_name="sentence-transformers/all-MiniLM-L6-v2"
+            )
+        return self._embedder.embed_query(text)
+
+    def _default_call_llm(self, prompt: str) -> str:
+        """Call the deployed LLM client with ``prompt``."""
+
+        if not gemini_service.is_available():
+            return "LLM service unavailable"
+        try:
+            response = gemini_service.model.generate_content(prompt)
+        except Exception:  # pragma: no cover - network/LLM errors
+            return "LLM request failed"
+        return getattr(response, "text", str(response))
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
     async def answer_simple(self, document_id: str, question: str) -> QAResponse:
         """Version 1: basic retrieval augmented generation."""
-        return QAResponse(answer="This is a placeholder answer.", sources=[])
+
+        answer = self._call_llm(question)
+        return QAResponse(answer=answer, sources=[])
 
     async def answer_with_citations(
         self, document_id: str, question: str

--- a/apps/api/blackletter_api/tests/unit/test_document_qa_service.py
+++ b/apps/api/blackletter_api/tests/unit/test_document_qa_service.py
@@ -1,0 +1,14 @@
+import asyncio
+
+from blackletter_api.services.document_qa import DocumentQAService
+
+
+async def _run_answer():
+    svc = DocumentQAService(embed_fn=lambda _: [0.0], llm_fn=lambda _: "stub")
+    return await svc.answer_simple("doc", "question")
+
+
+def test_injected_functions_used() -> None:
+    """DocumentQAService should use injected LLM function."""
+    result = asyncio.run(_run_answer())
+    assert result.answer == "stub"

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,3 +78,4 @@ wheel==0.45.1
 pytest==8.2.2
 google-generativeai==0.8.3
 pydantic-settings==2.0.3
+langchain==0.3.9


### PR DESCRIPTION
## Summary
- allow `DocumentQAService` to inject embedding and LLM functions
- default embedding uses LangChain sentence transformer
- default LLM call uses configured Gemini client
- add unit test covering injected LLM

## Testing
- `pip install langchain==0.3.9`
- `pytest apps/api/blackletter_api/tests -q` (fails: non-default argument 'last_activity' follows default argument)
- `pytest apps/api/blackletter_api/tests/unit/test_document_qa_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b32de94edc832fbb819bc3767b3ba6