### PR TITLE
[Infra] add Codex automation pack

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,20 @@
+area:api:
+  - apps/api/**/*
+area:web:
+  - apps/web/**/*
+area:infra:
+  - infra/**/*
+
+codex:codegen:
+  - '**/*.ts'
+  - '**/*.tsx'
+  - '**/*.py'
+codex:docs:
+  - docs/**/*
+
+size:S:
+  - changed-files: 1..50
+size:M:
+  - changed-files: 51..300
+size:L:
+  - changed-files: 301..

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+### What changed
+-
+
+### Why (risk / impact)
+-
+
+### Tests & Evidence
+- [ ] Backend: `pytest` output attached
+- [ ] Frontend: screenshot or story snapshot
+
+### Migrations
+- [ ] none  |  [ ] `alembic revision` → `alembic upgrade head` (rev: ___)
+
+### Rollback plan
+-
+
+@codex Focus on correctness, security, tests. Provide /patch for trivial fixes.

--- a/.github/workflows/codex-guard.yml
+++ b/.github/workflows/codex-guard.yml
@@ -1,0 +1,26 @@
+name: Codex • Guards
+on: [pull_request]
+jobs:
+  branch-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const ref = context.payload.pull_request.head.ref;
+            if (!/^codex\/[a-z0-9._-]+$/i.test(ref)) core.setFailed(`Branch must be 'codex/{feature}', got '${ref}'`);
+  size-limit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {owner:context.repo.owner, repo:context.repo.repo, pull_number:context.payload.pull_request.number});
+            const total = files.reduce((n,f)=>n+(f.changes||0),0);
+            if (total > 1500) core.setFailed(`PR too large (${total} LOC changed). Split it.`);
+  secret-skim:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          ! git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD | grep -E '\.env|\.pem|\.pfx|id_rsa' && echo "ok" || (echo "Secret-like files detected"; exit 1)

--- a/.github/workflows/codex-issues.yml
+++ b/.github/workflows/codex-issues.yml
@@ -1,0 +1,33 @@
+name: Codex • Issue to task
+on:
+  issues:
+    types: [opened, labeled]
+  issue_comment:
+    types: [created]
+jobs:
+  plan-or-fix:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'codex:run')) ||
+      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/codex'))
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create work branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const base = (await github.rest.repos.get({owner: context.repo.owner, repo: context.repo.repo})).data.default_branch;
+            const issue = context.payload.issue || (await github.rest.issues.get({owner:context.repo.owner, repo:context.repo.repo, issue_number: context.payload.issue.number})).data;
+            const feature = issue.title.toLowerCase().replace(/[^a-z0-9]+/g,'-').slice(0,60);
+            const ref = `codex/${feature}`;
+            const sha = (await github.rest.repos.getBranch({owner: context.repo.owner, repo: context.repo.repo, branch: base})).data.commit.sha;
+            try { await github.rest.git.createRef({owner: context.repo.owner, repo: context.repo.repo, ref: `refs/heads/${ref}`, sha}); } catch(e){}
+            core.setOutput('branch', ref);
+      - name: Open scaffold PR & summon @codex
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `[Plan] ${context.payload.issue.title}`;
+            const head = `${{ steps.plan-or-fix.outputs.branch || '' }}` || 'codex/tmp';
+            const pr = await github.rest.pulls.create({owner:context.repo.owner, repo:context.repo.repo, title, head, base: (await github.rest.repos.get({owner:context.repo.owner, repo:context.repo.repo})).data.default_branch, body: 'Auto-created from issue.\n\n@codex Please propose plan, tasks and initial diff.'});
+            await github.rest.issues.createComment({owner:context.repo.owner, repo:context.repo.repo, issue_number: pr.data.number, body: '@codex\n\nKick off planning with the **codegen** profile.'});

--- a/.github/workflows/codex-pr.yml
+++ b/.github/workflows/codex-pr.yml
@@ -1,0 +1,41 @@
+name: Codex • PR autopilot
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize, labeled]
+jobs:
+  summon:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: profile
+        run: |
+          # default profile
+          P="automation/codex/profile.review.v1.md"
+          # switch by label
+          for L in $(jq -r '.pull_request.labels[].name' <<< '${{ toJson(github.event) }}'); do
+            case "$L" in
+              codex:codegen) P="automation/codex/profile.codegen.v1.md" ;;
+              codex:docs)    P="automation/codex/profile.docs.v1.md" ;;
+              codex:explain) P="automation/codex/profile.explain.v1.md" ;;
+            esac
+          done
+          echo "path=$P" >> "$GITHUB_OUTPUT"
+          echo "body<<'EOF'" >> $GITHUB_OUTPUT
+          echo "@codex" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          cat "$P" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "**Repo:** $GITHUB_REPOSITORY  **PR:** #${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          echo "Branch: \`${{ github.event.pull_request.head.ref }}\` → Base: \`${{ github.event.pull_request.base.ref }}\`" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      - name: Post @codex with agent profile
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `${{ steps.profile.outputs.body }}`
+            })

--- a/.github/workflows/codex-schedule.yml
+++ b/.github/workflows/codex-schedule.yml
@@ -1,0 +1,25 @@
+name: Codex • Nightly upkeep
+on:
+  schedule: [{ cron: "12 2 * * *" }]  # daily 02:12 UTC
+  workflow_dispatch:
+jobs:
+  upkeep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Quick health (backend)
+        run: |
+          python -m pip install -r apps/api/requirements.txt || true
+          pytest -q apps/api || true
+      - name: Quick health (frontend)
+        run: |
+          corepack enable || true
+          pnpm -C apps/web install --frozen-lockfile || true
+          pnpm -C apps/web -r lint || true
+          pnpm -C apps/web -r build || true
+      - name: Ping @codex with status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = "@codex\n\nNightly upkeep complete. Summarize failures and propose patches if any.";
+            await github.rest.issues.create({owner:context.repo.owner, repo:context.repo.repo, title:"Nightly report", body});

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,11 @@
 ## Dev Agent Notes
 - See `web-bundles/agents/dev.txt`. Implement stories strictly via the “develop-story” flow; update only the allowed Dev Agent Record sections in story files; present numbered options when offering choices.
 
+
+## Automation Pack Baseline
+
+- Tests & lint must pass before merge.
+- No secrets/plaintext keys. Never commit .env or certs.
+- PR title format: [Area] summary; labels area:* size:* risk:*
+- Always mention @codex on PRs (workflow auto-injects).
+- Merge: squash after green + CODEOWNER approval.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,8 @@
+/apps/api/     @you @backend-owner
+/apps/web/     @you @frontend-owner
+/infra/        @you @devops-owner
+/rules/        @you @legaltech-owner
+
 # Core detector logic & rules need human eyes
 /apps/api/blackletter_api/services/detection.py  @v4mpire77
 /apps/api/blackletter_api/rules/**              @v4mpire77

--- a/apps/api/blackletter_api/services/code_sync_service.py
+++ b/apps/api/blackletter_api/services/code_sync_service.py
@@ -13,7 +13,7 @@ import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, field, asdict
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler, FileModifiedEvent, FileCreatedEvent, FileDeletedEvent
 import hashlib
@@ -31,11 +31,7 @@ class CodeChange:
     file_hash: str
     previous_hash: Optional[str] = None
     conflict_level: str = 'low'  # 'low', 'medium', 'high', 'critical'
-    affected_agents: List[str] = None
-    
-    def __post_init__(self):
-        if self.affected_agents is None:
-            self.affected_agents = []
+    affected_agents: List[str] = field(default_factory=list)
 
 @dataclass
 class CodeConflict:
@@ -54,14 +50,10 @@ class AgentStatus:
     """Represents the current status of an AI agent"""
     agent_id: str
     status: str  # 'active', 'idle', 'busy', 'error', 'offline'
+    last_activity: datetime = field(default_factory=datetime.now)
     current_task: Optional[str] = None
-    last_activity: datetime
     workload: float = 0.0  # 0.0 to 1.0
-    capabilities: List[str] = None
-    
-    def __post_init__(self):
-        if self.capabilities is None:
-            self.capabilities = []
+    capabilities: List[str] = field(default_factory=list)
 
 class CodeSyncService:
     """

--- a/automation/codex/profile.codegen.v1.md
+++ b/automation/codex/profile.codegen.v1.md
@@ -1,0 +1,13 @@
+You are Codex acting as Code Generator.
+
+Rules:
+- Branch: codex/{feature-kebab}
+- Conventional commits
+- Add docstrings/comments and minimal tests
+- Keep patches atomic; no unrelated churn
+
+Deliver:
+- Diff-ready code
+- Test files
+- Update docs if public API changes
+Then open PR and mention @codex to self-review with profile.review.v1.

--- a/automation/codex/profile.docs.v1.md
+++ b/automation/codex/profile.docs.v1.md
@@ -1,0 +1,2 @@
+You are Codex acting as Docs Engineer.
+Normalize README, /docs, API reference. Enforce clarity, Windows-first instructions, and runnable snippets.

--- a/automation/codex/profile.explain.v1.md
+++ b/automation/codex/profile.explain.v1.md
@@ -1,0 +1,2 @@
+You are Codex acting as Explainer.
+Explain purpose, flow, edge cases, and improvements; include quick-start commands.

--- a/automation/codex/profile.review.v1.md
+++ b/automation/codex/profile.review.v1.md
@@ -1,0 +1,14 @@
+You are Codex acting as Senior Reviewer (security + tests + DX).
+
+Do:
+- Map changes → risks; cite lines; make a checklist.
+- Fail the review if: secrets, missing tests for new logic, failing build, unsafe migrations.
+- Provide a /patch (unified diff) for trivial fixes (lint, typo, imports, minor bugs).
+Verify:
+- Backend: run pytest (or propose exact commands); if migrations changed → `alembic upgrade head`.
+- Frontend: pnpm install, lint, test, build.
+Outputs:
+- Summary (bullets)
+- Risks & mitigations
+- /patch (if any)
+- Follow-ups (label `tech-debt` if needed)


### PR DESCRIPTION
## What changed
- add Codex automation pack: agent profiles, PR/issue/guard/nightly workflows, labeler, PR template, and baseline rules
- fix API code sync service dataclass defaults to avoid initialization errors

## Why (risk, user impact)
- enable always-on Codex automation for reviews and maintenance
- unblock API test collection by correcting dataclass field order

## Tests & Evidence
- Backend: `pytest -q apps/api` *(fails: OperationalError no such table: analyses; rulepack parsing errors)*
- Frontend: `pnpm -C apps/web lint` *(fails with no-explicit-any errors)*, `pnpm -C apps/web test -- --run` *(no tests found)*, `pnpm -C apps/web build`

## Migration note
- none

## Rollback plan
- revert this commit

@codex

------
https://chatgpt.com/codex/tasks/task_e_68b3a0faa158832fafa3add56af6e5ed