### PR TITLE
[API] add analysis timestamp metadata

### DIFF
--- a/apps/api/blackletter_api/routers/risk_analysis.py
+++ b/apps/api/blackletter_api/routers/risk_analysis.py
@@ -11,7 +11,8 @@ Provides endpoints for advanced contract risk analysis including:
 
 from __future__ import annotations
 
-from typing import List, Dict, Any
+from datetime import datetime
+from typing import Any, Dict, List
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
@@ -98,7 +99,7 @@ async def analyze_contract_risk(request: RiskAnalysisRequest) -> RiskAnalysisRes
             "text_analyzed": len(contract_text) > 0,
             "findings_analyzed": len(findings) > 0,
             "risk_categories_analyzed": len(risk_profile.risk_factors),
-            "analysis_timestamp": "2025-01-27T12:00:00Z"  # TODO: Use actual timestamp
+            "analysis_timestamp": datetime.utcnow().isoformat(),
         }
         
         return RiskAnalysisResponse(

--- a/apps/api/blackletter_api/tests/unit/test_risk_analysis_router.py
+++ b/apps/api/blackletter_api/tests/unit/test_risk_analysis_router.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+from blackletter_api.main import app
+from blackletter_api.services.ai_risk_scorer import ContractRiskProfile, RiskLevel
+
+
+client = TestClient(app)
+
+
+def test_risk_analysis_returns_iso_timestamp(monkeypatch) -> None:
+    dummy_profile = ContractRiskProfile(
+        overall_score=0.0,
+        overall_level=RiskLevel.LOW,
+        risk_factors=[],
+        summary="",
+        urgent_actions=[],
+        monitoring_points=[],
+    )
+
+    def fake_analyze_contract_risk(contract_text: str, findings: list) -> ContractRiskProfile:
+        return dummy_profile
+
+    monkeypatch.setattr(
+        "blackletter_api.routers.risk_analysis.ai_risk_scorer.analyze_contract_risk",
+        fake_analyze_contract_risk,
+    )
+
+    res = client.post("/api/risk-analysis", json={"analysis_id": "test"})
+    assert res.status_code == 200
+    ts = res.json()["metadata"]["analysis_timestamp"]
+    # ensure timestamp is valid ISO format
+    datetime.fromisoformat(ts)
+    assert "T" in ts


### PR DESCRIPTION
## What changed
- return ISO-formatted `analysis_timestamp` in risk analysis metadata
- add test covering `analysis_timestamp` format

## Why (risk, user impact)
- provides callers with a reliable timestamp for each analysis response

## Tests & Evidence
- `pip install -r apps/api/requirements.txt`
- `pytest -q apps/api` *(fails: AttributeError: module 'blackletter_api.routers.rules' has no attribute 'router')*

## Migration note
- none

## Rollback plan
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68b6334d02b4832f9e0fb7a7ba5969fb