### PR TITLE
[API] add regex detector support

### DIFF
--- a/apps/api/blackletter_api/services/detector_runner.py
+++ b/apps/api/blackletter_api/services/detector_runner.py
@@ -175,8 +175,28 @@ def run_detectors(analysis_id: str, extraction_json_path: str) -> List[Finding]:
                     finding.verdict = final_verdict
                     findings.append(finding)
             elif detector_spec.type == "regex":
-                # TODO: Implement regex detector logic
-                pass # For now, skip regex detectors
+                pattern = detector_spec.pattern or ""
+                try:
+                    regex = re.compile(pattern, re.IGNORECASE)
+                except re.error:
+                    continue
+                if regex.search(sentence_text):
+                    finding = Finding(
+                        detector_id=detector_id,
+                        rule_id=detector_id,
+                        verdict="pass",
+                        snippet=sentence_text,
+                        page=page,
+                        start=start,
+                        end=end,
+                        rationale=f"Regex pattern '{pattern}' matched.",
+                    )
+                    final_verdict = postprocess_weak_language(
+                        original_verdict=finding.verdict,
+                        window_text=finding.snippet,
+                    )
+                    finding.verdict = final_verdict
+                    findings.append(finding)
 
         processed_sentences += 1
 

--- a/apps/api/blackletter_api/tests/unit/test_detector_runner.py
+++ b/apps/api/blackletter_api/tests/unit/test_detector_runner.py
@@ -3,9 +3,23 @@ from __future__ import annotations
 import json
 import uuid
 from pathlib import Path
+from typing import Any
 
 from blackletter_api.services.detector_runner import run_detectors
-from blackletter_api.services.rulepack_loader import Rulepack, Detector, Lexicon
+import blackletter_api.services.rulepack_loader as rl
+from blackletter_api.services.weak_lexicon import (
+    get_weak_terms_with_metadata,
+    get_counter_anchors,
+)
+
+rl.Any = Any  # Ensure forward references are resolved
+rl.Lexicon.model_rebuild()
+rl.Detector.model_rebuild()
+rl.Rulepack.model_rebuild()
+
+Rulepack = rl.Rulepack
+Detector = rl.Detector
+Lexicon = rl.Lexicon
 
 
 def test_run_detectors_generates_findings_and_applies_weak_language(tmp_path: Path, monkeypatch):
@@ -20,6 +34,21 @@ def test_run_detectors_generates_findings_and_applies_weak_language(tmp_path: Pa
         lambda aid: analysis_dir_temp
     )
 
+    class DummyLedger:
+        def add_tokens(self, *args, **kwargs):
+            return False, None
+
+    monkeypatch.setattr(
+        "blackletter_api.services.detector_runner.get_token_ledger",
+        lambda: DummyLedger(),
+    )
+    monkeypatch.setattr(
+        "blackletter_api.services.detector_runner.should_apply_token_capping",
+        lambda: False,
+    )
+    get_weak_terms_with_metadata.cache_clear()
+    get_counter_anchors.cache_clear()
+
     # Mock the load_rulepack function
     mock_rulepack = Rulepack(
         name="test-rulepack",
@@ -33,13 +62,14 @@ def test_run_detectors_generates_findings_and_applies_weak_language(tmp_path: Pa
             )
         ],
         lexicons={
-            "weak-language": Lexicon(
-                name="weak-language",
+            "weak_language": Lexicon(
+                name="weak_language",
                 terms=["may", "might", "could", "should"]
             )
         }
     )
     monkeypatch.setattr("blackletter_api.services.detector_runner.load_rulepack", lambda: mock_rulepack)
+    monkeypatch.setattr("blackletter_api.services.weak_lexicon.load_rulepack", lambda: mock_rulepack)
 
     # Create a dummy extraction.json with sentences, some containing weak language terms
     dummy_extraction = {
@@ -82,3 +112,76 @@ def test_run_detectors_generates_findings_and_applies_weak_language(tmp_path: Pa
     assert finding2["rule_id"] == "D001"
     assert finding2["snippet"] == "Another sentence could be here."
     assert finding2["verdict"] == "weak" # Should be downgraded by post-processor
+
+
+def test_run_detectors_handles_regex_detectors(tmp_path: Path, monkeypatch):
+    """Ensure regex-based detectors generate findings and persist them."""
+    analysis_id = str(uuid.uuid4())
+
+    analysis_dir_temp = tmp_path / analysis_id
+    analysis_dir_temp.mkdir()
+
+    monkeypatch.setattr(
+        "blackletter_api.services.detector_runner.analysis_dir",
+        lambda aid: analysis_dir_temp
+    )
+
+    class DummyLedger:
+        def add_tokens(self, *args, **kwargs):
+            return False, None
+
+    monkeypatch.setattr(
+        "blackletter_api.services.detector_runner.get_token_ledger",
+        lambda: DummyLedger(),
+    )
+    monkeypatch.setattr(
+        "blackletter_api.services.detector_runner.should_apply_token_capping",
+        lambda: False,
+    )
+    get_weak_terms_with_metadata.cache_clear()
+    get_counter_anchors.cache_clear()
+
+    mock_rulepack = Rulepack(
+        name="regex-pack",
+        version="v1",
+        detectors=[
+            Detector(
+                id="R001",
+                type="regex",
+                pattern=r"foo\d+",
+                description="Matches foo followed by digits",
+            )
+        ],
+        lexicons={}
+    )
+
+    monkeypatch.setattr("blackletter_api.services.detector_runner.load_rulepack", lambda: mock_rulepack)
+    monkeypatch.setattr("blackletter_api.services.weak_lexicon.load_rulepack", lambda: mock_rulepack)
+
+    dummy_extraction = {
+        "text_path": "extracted.txt",
+        "page_map": [{"page": 1, "start": 0, "end": 50}],
+        "sentences": [
+            {"page": 1, "start": 0, "end": 25, "text": "This sentence has FoO123 pattern."},
+            {"page": 1, "start": 26, "end": 50, "text": "Nothing to see here."}
+        ]
+    }
+
+    extraction_path = analysis_dir_temp / "extraction.json"
+    with extraction_path.open("w") as f:
+        json.dump(dummy_extraction, f)
+
+    run_detectors(analysis_id, str(extraction_path))
+
+    findings_path = analysis_dir_temp / "findings.json"
+    assert findings_path.exists()
+
+    with findings_path.open("r") as f:
+        findings = json.load(f)
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["detector_id"] == "R001"
+    assert finding["rule_id"] == "R001"
+    assert finding["snippet"] == "This sentence has FoO123 pattern."
+    assert finding["verdict"] == "pass"


### PR DESCRIPTION
## What changed
- add regex-based detector logic
- test regex detection persistence

## Why (risk, user impact)
- enables rulepack patterns to trigger findings without LLM usage

## Tests & Evidence
- `pip install -r apps/api/requirements.txt`
- `pytest -q apps/api` *(fails: ModuleNotFoundError: No module named 'passlib')*
- `pytest -q apps/api/blackletter_api/tests/unit/test_detector_runner.py`

## Migration note (alembic)
- none

## Rollback plan
- revert commit

------
https://chatgpt.com/codex/tasks/task_e_68b6334bd23c832fa5d79c5a2e743095