### PR TITLE
fix(web): allow upload simulation to resume

### DIFF
--- a/apps/web/src/app/new/page.tsx
+++ b/apps/web/src/app/new/page.tsx
@@ -158,7 +158,14 @@ export default function NewUploadPage() {
               </div>
               <div className="flex gap-2">
                 {!running && current !== "done" && (
-                  <button className="rounded border px-3 py-1 text-sm" onClick={() => setRunning(true)}>
+                  <button
+                    className="rounded border px-3 py-1 text-sm"
+                    onClick={() => {
+                      cancelledRef.current = false;
+                      setCanceled(false);
+                      setRunning(true);
+                    }}
+                  >
                     Resume
                   </button>
                 )}

--- a/apps/web/test/components/NewUploadPage.test.tsx
+++ b/apps/web/test/components/NewUploadPage.test.tsx
@@ -93,6 +93,43 @@ describe("NewUploadPage State Machine", () => {
     });
   });
 
+  test("resumes the upload simulation after canceling", () => {
+    render(<NewUploadPage />);
+    const file = new File(["contract"], "test.pdf", { type: "application/pdf" });
+
+    const input = screen.getByTestId("file-input");
+    act(() => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+
+    const stateMachine = screen.getByTestId("state-machine");
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(stateMachine).toHaveAttribute("data-state", "extracting");
+
+    const cancelButton = screen.getByRole("button", { name: /cancel/i });
+    act(() => {
+      fireEvent.click(cancelButton);
+    });
+
+    // Timer shouldn't advance while canceled
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(stateMachine).toHaveAttribute("data-state", "extracting");
+
+    const resumeButton = screen.getByRole("button", { name: /resume/i });
+    act(() => {
+      fireEvent.click(resumeButton);
+    });
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(stateMachine).toHaveAttribute("data-state", "detecting");
+  });
+
   test("resets the upload simulation", () => {
     render(<NewUploadPage />);
     const file = new File(["contract"], "test.pdf", { type: "application/pdf" });


### PR DESCRIPTION
## Summary
- clear cancellation flag and reset state when resuming upload simulation
- test resuming after cancel to ensure mock upload continues

## Testing
- `npm test test/components`


------
https://chatgpt.com/codex/tasks/task_e_68b642fac1fc832f8005c110e429454d