### PR TITLE
[API] preserve analysis timestamps

### DIFF
--- a/apps/api/blackletter_api/orchestrator/state.py
+++ b/apps/api/blackletter_api/orchestrator/state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from enum import Enum
 import threading
 from typing import Dict, List, Any
@@ -22,6 +23,7 @@ class AnalysisRecord:
     id: str
     filename: str
     state: AnalysisState = AnalysisState.RECEIVED
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     findings: List[Dict[str, Any]] = field(default_factory=list)
 
 

--- a/apps/api/blackletter_api/routers/analyses.py
+++ b/apps/api/blackletter_api/routers/analyses.py
@@ -52,7 +52,7 @@ def list_analyses(limit: int = Query(default=50, ge=1, le=200)) -> List[Analysis
             AnalysisSummary(
                 id=rec.id,
                 filename=rec.filename,
-                created_at=datetime.now(timezone.utc).isoformat(),
+                created_at=rec.created_at.isoformat(),
                 size=0,
                 state=rec.state.value,
                 verdicts=VerdictCounts(),

--- a/apps/api/blackletter_api/tests/unit/test_analyses_router.py
+++ b/apps/api/blackletter_api/tests/unit/test_analyses_router.py
@@ -16,6 +16,16 @@ def test_list_analyses_empty():
     assert body == []
 
 
+def test_list_analyses_preserves_created_at():
+    orchestrator._store.clear()
+    analysis_id = orchestrator.intake("contract.pdf")
+    created_at = orchestrator.summary(analysis_id).created_at.isoformat()
+    res = client.get("/api/analyses?limit=50")
+    assert res.status_code == 200
+    body = res.json()
+    assert body[0]["created_at"] == created_at
+
+
 def test_analysis_summary_not_found():
     orchestrator._store.clear()
     res = client.get("/api/analyses/missing")

--- a/apps/api/blackletter_api/tests/unit/test_orchestrator_state.py
+++ b/apps/api/blackletter_api/tests/unit/test_orchestrator_state.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from threading import Thread
 
 from blackletter_api.orchestrator.state import Orchestrator, AnalysisState
@@ -36,3 +37,13 @@ def test_concurrent_advance_no_keyerror_or_lost_updates():
     record = orch.summary(analysis_id)
     assert record.state == AnalysisState.EXTRACTED
     assert sorted(f["issue"] for f in record.findings) == list(range(5))
+
+
+def test_created_at_preserved_across_advances():
+    orch = Orchestrator()
+    analysis_id = orch.intake("contract.pdf")
+    initial_ts = orch.summary(analysis_id).created_at
+    assert isinstance(initial_ts, datetime)
+    orch.advance(analysis_id, AnalysisState.EXTRACTED)
+    updated_ts = orch.summary(analysis_id).created_at
+    assert updated_ts == initial_ts


### PR DESCRIPTION
## What changed
- track `created_at` on analysis records
- surface stored timestamps in `/analyses` responses
- test coverage for timestamp persistence

## Why (risk, user impact)
Ensures analysis creation times are recorded and returned consistently, enabling chronological listings.

## Tests & Evidence
- `pip install -r apps/api/requirements.txt`
- `pip install passlib`
- `pytest -q apps/api` *(fails: module 'blackletter_api.routers.rules' has no attribute 'router')*

## Migration note
none

## Rollback plan
Revert this PR.


------
https://chatgpt.com/codex/tasks/task_e_68b643fb09a8832fafbfee07b1d12d38