### PR TITLE
[UI] add reports stub and dialog accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ npm install
 npm run dev
 ```
 
+### Demo Mode
+
+To run the UI without a backend, enable mock data by setting `NEXT_PUBLIC_USE_MOCKS=1` in your environment. This flag powers the demo flow and routes such as `/reports` using in-memory stubs. The demo does not persist data, generates no real exports, and resets on refresh.
+
 ## 🎯 **Next Development Priorities**
 
 ### Ready to Start (Epic 2 Completion)

--- a/apps/web/src/app/reports/page.test.tsx
+++ b/apps/web/src/app/reports/page.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import ReportsPage from './page';
+
+describe('ReportsPage', () => {
+  it('renders stub text', () => {
+    render(<ReportsPage />);
+    expect(screen.getByText(/Report history will appear here/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/reports/page.tsx
+++ b/apps/web/src/app/reports/page.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function ReportsPage() {
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold">Reports</h1>
+      <p>Report history will appear here.</p>
+    </main>
+  );
+}

--- a/apps/web/src/components/EvidenceDrawer.test.tsx
+++ b/apps/web/src/components/EvidenceDrawer.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import EvidenceDrawer from './EvidenceDrawer';
+import { vi } from 'vitest';
+
+describe('EvidenceDrawer', () => {
+  it('closes on Escape key', () => {
+    const onClose = vi.fn();
+    render(
+      <EvidenceDrawer isOpen onClose={onClose}>
+        <p>content</p>
+      </EvidenceDrawer>
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/EvidenceDrawer.tsx
+++ b/apps/web/src/components/EvidenceDrawer.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+
+interface EvidenceDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export default function EvidenceDrawer({ isOpen, onClose, children }: EvidenceDrawerProps) {
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      } else if (e.key === 'Tab' && drawerRef.current) {
+        const focusable = drawerRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+
+    if (isOpen) {
+      drawerRef.current?.focus();
+      document.addEventListener('keydown', handleKeyDown);
+    }
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-40">
+      <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+      <div
+        ref={drawerRef}
+        tabIndex={-1}
+        className="absolute right-0 top-0 h-full w-80 bg-white p-4 shadow-lg"
+      >
+        {children}
+        <div className="mt-4 flex justify-end">
+          <button onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ExportDialog.test.tsx
+++ b/apps/web/src/components/ExportDialog.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import ExportDialog from './ExportDialog';
+import { vi } from 'vitest';
+
+const push = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}));
+
+describe('ExportDialog', () => {
+  it('navigates to reports on confirm', () => {
+    const onClose = vi.fn();
+    const { getByText } = render(<ExportDialog isOpen onClose={onClose} />);
+    fireEvent.click(getByText('Confirm'));
+    expect(push).toHaveBeenCalledWith('/reports');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes on Escape key', () => {
+    const onClose = vi.fn();
+    render(<ExportDialog isOpen onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/ExportDialog.tsx
+++ b/apps/web/src/components/ExportDialog.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface ExportDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function ExportDialog({ isOpen, onClose }: ExportDialogProps) {
+  const router = useRouter();
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      } else if (e.key === 'Tab' && dialogRef.current) {
+        const focusable = dialogRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable.length === 0) {
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+
+    if (isOpen) {
+      dialogRef.current?.focus();
+      document.addEventListener('keydown', handleKeyDown);
+    }
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  const handleConfirm = () => {
+    router.push('/reports');
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        className="relative z-10 rounded bg-white p-4 shadow-md"
+      >
+        <p className="mb-4">Export this analysis?</p>
+        <div className="flex justify-end gap-2">
+          <button onClick={onClose}>Cancel</button>
+          <button onClick={handleConfirm}>Confirm</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/VerdictChips.test.tsx
+++ b/apps/web/src/components/VerdictChips.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import VerdictChips from './VerdictChips';
+
+describe('VerdictChips', () => {
+  it('adds an aria-label for accessibility', () => {
+    const { getByText } = render(<VerdictChips verdict="pass" />);
+    const chip = getByText(/pass/i);
+    expect(chip).toHaveAttribute('aria-label', 'Pass');
+  });
+});

--- a/apps/web/src/components/VerdictChips.tsx
+++ b/apps/web/src/components/VerdictChips.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import React, { useMemo } from 'react';
+
+interface VerdictChipsProps {
+  verdict: string;
+}
+
+export default function VerdictChips({ verdict }: VerdictChipsProps) {
+  const chipStyle = useMemo(() => {
+    switch (verdict.toLowerCase()) {
+      case 'pass':
+        return 'bg-green-100 text-green-800';
+      case 'weak':
+        return 'bg-yellow-100 text-yellow-800';
+      case 'missing':
+        return 'bg-red-100 text-red-800';
+      case 'needs_review':
+        return 'bg-blue-100 text-blue-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
+    }
+  }, [verdict]);
+
+  const ariaLabel = useMemo(() => {
+    switch (verdict.toLowerCase()) {
+      case 'pass':
+        return 'Pass';
+      case 'weak':
+        return 'Weak';
+      case 'missing':
+        return 'Missing';
+      case 'needs_review':
+        return 'Needs Review';
+      default:
+        return 'Unknown';
+    }
+  }, [verdict]);
+
+  return (
+    <span className={`px-2 py-1 text-xs font-semibold rounded-full ${chipStyle}`} aria-label={ariaLabel}>
+      {verdict.replace('_', ' ')}
+    </span>
+  );
+}


### PR DESCRIPTION
## What changed
- add `/reports` stub page and hook export dialog confirm to navigate there
- trap focus and close on ESC for dialogs and drawers; add ARIA labels to verdict chips
- document `NEXT_PUBLIC_USE_MOCKS` demo flag and limitations

## Why (risk, user impact)
- prepares reports workflow and improves keyboard accessibility; low risk

## Tests & Evidence
- `node node_modules/vitest/vitest.mjs run`
- `pnpm typecheck`
- `pnpm build`

## Migration note (alembic)
- none

## Rollback plan
- revert this commit


------
https://chatgpt.com/codex/tasks/task_e_68b6440bca30832fb19973aa07862829