### PR TITLE
[API] connect DocumentQAService to vector store and LLM

### DIFF
--- a/apps/api/blackletter_api/tests/unit/test_document_qa_service.py
+++ b/apps/api/blackletter_api/tests/unit/test_document_qa_service.py
@@ -1,0 +1,69 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from blackletter_api.services.document_qa import DocumentQAService
+from blackletter_api.models.schemas import QASource
+
+
+@pytest.mark.asyncio
+async def test_answer_simple_uses_vector_store_and_llm() -> None:
+    vector_store = AsyncMock()
+    vector_store.search.return_value = [QASource(page=1, content="chunk")]
+    llm = AsyncMock()
+    llm.generate.return_value = "final answer"
+    service = DocumentQAService(vector_store=vector_store, llm=llm)
+
+    res = await service.answer_simple("doc", "question")
+
+    assert res.answer == "final answer"
+    assert res.sources == []
+    vector_store.search.assert_awaited_once()
+    llm.generate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_answer_with_citations_returns_sources() -> None:
+    src = QASource(page=2, content="evidence")
+    vector_store = AsyncMock()
+    vector_store.search.return_value = [src]
+    llm = AsyncMock()
+    llm.generate.return_value = "answer"
+    service = DocumentQAService(vector_store=vector_store, llm=llm)
+
+    res = await service.answer_with_citations("doc", "question")
+
+    assert res.sources == [src]
+    vector_store.search.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_answer_with_history_includes_chat_history() -> None:
+    vector_store = AsyncMock()
+    vector_store.search.return_value = []
+    llm = AsyncMock()
+    llm.generate.return_value = "answer"
+    service = DocumentQAService(vector_store=vector_store, llm=llm)
+
+    await service.answer_with_history("doc", "question", ["hi there"])
+
+    prompt = llm.generate.call_args[0][0]
+    assert "hi there" in prompt
+
+
+@pytest.mark.asyncio
+async def test_answer_hybrid_combines_search_results() -> None:
+    sem = QASource(page=1, content="sem")
+    kw = QASource(page=2, content="kw")
+    vector_store = AsyncMock()
+    vector_store.search.return_value = [sem]
+    vector_store.keyword_search.return_value = [kw]
+    llm = AsyncMock()
+    llm.generate.return_value = "answer"
+    service = DocumentQAService(vector_store=vector_store, llm=llm)
+
+    res = await service.answer_hybrid("doc", "question")
+
+    pages = {s.page for s in res.sources}
+    assert pages == {1, 2}
+    vector_store.search.assert_awaited_once()
+    vector_store.keyword_search.assert_awaited_once()


### PR DESCRIPTION
## What changed
- connect `DocumentQAService` to pluggable vector store and LLM client
- implement simple, citations, conversational and hybrid modes via shared helpers
- add unit tests mocking vector store and LLM

## Why (risk, user impact)
- enables richer document Q&A strategies; medium risk due to new async integrations

## Tests & Evidence
- `pip install -r apps/api/requirements.txt`
- `pytest -q apps/api` *(fails: module 'blackletter_api.routers.rules' has no attribute 'router')*
- `pytest apps/api/blackletter_api/tests/unit/test_document_qa_service.py -q`

## Migration note
none

## Rollback plan
Revert this commit.


------
https://chatgpt.com/codex/tasks/task_e_68b644627c00832fb91b4df68294f4b1