### PR TITLE
[API] handle dead websockets in broadcast

### DIFF
--- a/apps/api/blackletter_api/main.py
+++ b/apps/api/blackletter_api/main.py
@@ -42,12 +42,16 @@ class ConnectionManager:
         await websocket.send_text(message)
 
     async def broadcast(self, message: str):
-        for connection in self.active_connections:
+        dead_connections: List[WebSocket] = []
+        for connection in list(self.active_connections):
             try:
                 await connection.send_text(message)
-            except:
-                # Remove dead connections
-                self.active_connections.remove(connection)
+            except Exception as exc:
+                logger.warning(f"Failed to send message: {exc}")
+                dead_connections.append(connection)
+
+        for connection in dead_connections:
+            self.disconnect(connection)
 
 manager = ConnectionManager()
 

--- a/apps/api/blackletter_api/tests/unit/test_connection_manager.py
+++ b/apps/api/blackletter_api/tests/unit/test_connection_manager.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+import sys
+from types import ModuleType
+from fastapi import APIRouter
+
+# Stub router modules to avoid heavy dependencies during import
+for _module in [
+    "blackletter_api.routers.rules",
+    "blackletter_api.routers.analyses",
+    "blackletter_api.routers.contracts",
+    "blackletter_api.routers.jobs",
+    "blackletter_api.routers.reports",
+    "blackletter_api.routers.risk_analysis",
+    "blackletter_api.routers.admin",
+    "blackletter_api.routers.orchestration",
+    "blackletter_api.routers.gemini",
+    "blackletter_api.routers.document_qa",
+    "blackletter_api.routers.auth",
+]:
+    module = ModuleType(_module)
+    module.router = APIRouter()
+    sys.modules[_module] = module
+
+from blackletter_api.main import ConnectionManager
+
+
+@pytest.mark.asyncio
+async def test_broadcast_removes_dead_connections(caplog: pytest.LogCaptureFixture) -> None:
+    manager = ConnectionManager()
+
+    good_ws = AsyncMock()
+    bad_ws = AsyncMock()
+    good_ws.send_text = AsyncMock()
+    bad_ws.send_text = AsyncMock(side_effect=Exception("boom"))
+
+    manager.active_connections.extend([good_ws, bad_ws])
+
+    with caplog.at_level(logging.WARNING):
+        await manager.broadcast("hi")
+
+    assert good_ws in manager.active_connections
+    assert bad_ws not in manager.active_connections
+    assert "Failed to send message" in caplog.text


### PR DESCRIPTION
## What changed
- safely remove dead websocket connections after broadcast
- add test covering cleanup of failed websocket sends

## Why (risk, user impact)
- prevents stale sockets from persisting and consuming resources

## Tests & Evidence
- `pip install -r apps/api/requirements.txt`
- `pytest -q apps/api` *(fails: missing modules)*
- `pytest apps/api/blackletter_api/tests/unit/test_connection_manager.py -q`

## Migration note
- none

## Rollback plan
- revert this PR


------
https://chatgpt.com/codex/tasks/task_e_68b64461466c832fa046fcbd053b9a62