### PR TITLE
[API] handle sqlite connect args conditionally

### DIFF
--- a/apps/api/blackletter_api/database.py
+++ b/apps/api/blackletter_api/database.py
@@ -1,12 +1,17 @@
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.engine.url import make_url
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+from .config import settings
 
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
-)
+SQLALCHEMY_DATABASE_URL = settings.database_url
+
+engine_kwargs = {}
+if make_url(SQLALCHEMY_DATABASE_URL).drivername == "sqlite":
+    engine_kwargs["connect_args"] = {"check_same_thread": False}
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL, **engine_kwargs)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()

--- a/apps/api/blackletter_api/tests/unit/test_database_engine.py
+++ b/apps/api/blackletter_api/tests/unit/test_database_engine.py
@@ -1,0 +1,55 @@
+import importlib
+from pathlib import Path
+
+import pytest
+import sqlalchemy
+
+from blackletter_api import config, database
+from blackletter_api.models import entities
+
+
+def _reload_database(monkeypatch: pytest.MonkeyPatch, url: str) -> dict:
+    called: dict = {}
+
+    def fake_create_engine(url_arg: str, **kwargs):
+        called["url"] = url_arg
+        called["kwargs"] = kwargs
+
+        class DummyEngine:
+            pass
+
+        return DummyEngine()
+
+    monkeypatch.setattr(sqlalchemy, "create_engine", fake_create_engine)
+    monkeypatch.setattr(config, "settings", config.Settings(database_url=url))
+    importlib.reload(database)
+    return called
+
+
+@pytest.fixture(autouse=True)
+def restore_database() -> None:
+    original_settings = config.settings
+    yield
+    config.settings = original_settings
+    importlib.reload(database)
+    db_path = Path(__file__).resolve().parents[3] / "test.db"
+    real_engine = sqlalchemy.create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    database.engine = real_engine
+    database.SessionLocal.configure(bind=real_engine)
+    entities.Base.metadata.create_all(bind=real_engine)
+
+
+def test_engine_creation_sqlite(monkeypatch: pytest.MonkeyPatch) -> None:
+    info = _reload_database(monkeypatch, "sqlite:///:memory:")
+    assert info["kwargs"]["connect_args"] == {"check_same_thread": False}
+    assert info["url"] == "sqlite:///:memory:"
+
+
+def test_engine_creation_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
+    info = _reload_database(
+        monkeypatch, "postgresql://user:pass@localhost/db"
+    )
+    assert "connect_args" not in info["kwargs"]
+    assert info["url"] == "postgresql://user:pass@localhost/db"


### PR DESCRIPTION
## What changed
- Create DB engine from `settings.database_url`
- Only apply SQLite `connect_args` when using a SQLite URL
- Add unit tests for SQLite and Postgres engine creation

## Why (risk, user impact)
- Prevents passing SQLite-only options to other databases, ensuring correct engine initialization

## Tests & Evidence
- `pip install -r apps/api/requirements.txt --break-system-packages`
- `pip install pytest sqlalchemy pydantic-settings httpx PyMuPDF docx2python blingfire numpy python-multipart watchdog --break-system-packages`
- `pytest -q apps/api` *(fails: ModuleNotFoundError: No module named 'google')*

## Migration note (alembic)
- none

## Rollback plan
- Revert this PR


------
https://chatgpt.com/codex/tasks/task_e_68b6445ffa9c832fa25929251c250bd9