### PR TITLE
[API] enforce SECRET_KEY configuration

### DIFF
--- a/apps/api/blackletter_api/config.py
+++ b/apps/api/blackletter_api/config.py
@@ -2,7 +2,6 @@
 Configuration settings for Blackletter API
 """
 
-import os
 from typing import Optional
 from pydantic_settings import BaseSettings
 from pydantic import Field
@@ -27,7 +26,7 @@ class Settings(BaseSettings):
     log_level: str = Field(default="INFO", env="LOG_LEVEL")
 
     # Security settings
-    secret_key: str = Field(default="your-secret-key-here", env="SECRET_KEY")
+    secret_key: str = Field(..., env="SECRET_KEY")
 
     class Config:
         env_file = ".env"

--- a/apps/api/blackletter_api/tests/unit/test_config.py
+++ b/apps/api/blackletter_api/tests/unit/test_config.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import importlib
+import pytest
+from pydantic import ValidationError
+
+
+def test_settings_requires_secret_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SECRET_KEY", "test")
+    config = importlib.import_module("blackletter_api.config")
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    with pytest.raises(ValidationError):
+        config.Settings()


### PR DESCRIPTION
## What changed
- Remove unused `os` import and require `SECRET_KEY` to be provided via environment
- Add unit test ensuring `Settings` raises validation error when `SECRET_KEY` is missing

## Why (risk, user impact)
- Eliminates hard-coded secret and enforces explicit configuration for stronger security

## Tests & Evidence
- `SECRET_KEY=test pytest -q apps/api/blackletter_api/tests` *(fails: module 'blackletter_api.routers.rules' has no attribute 'router')*

## Migration note (alembic)
- none

## Rollback plan
- Revert these commits

------
https://chatgpt.com/codex/tasks/task_e_68b6445f0ef8832f93735f02835ef02b