### PR TITLE
[API] remove duplicate summary schemas

### DIFF
--- a/apps/api/blackletter_api/models/schemas.py
+++ b/apps/api/blackletter_api/models/schemas.py
@@ -119,21 +119,6 @@ class ContractValidationStatus(BaseModel):
     timestamp: datetime
 
 
-class DetectorSummary(BaseModel):
-    id: str
-    type: str
-    description: Optional[str] = None
-    lexicon: Optional[str] = None
-
-
-class RulesSummary(BaseModel):
-    name: str
-    version: str
-    detector_count: int
-    detectors: List[DetectorSummary]
-    lexicons: List[str]
-
-
 class QASource(BaseModel):
     """Source citation for a Q&A response."""
     page: int


### PR DESCRIPTION
## What changed
- Remove duplicate `DetectorSummary` and `RulesSummary` declarations in `schemas.py`.

## Why (risk, user impact)
- Avoids conflicting schema definitions and clarifies API models.

## Tests & Evidence
- `pip install -r apps/api/requirements.txt`
- `pip install passlib`
- `pytest -q apps/api/blackletter_api/tests` *(fails: AttributeError: module 'blackletter_api.routers.rules' has no attribute 'router')*

## Migration note
- none

## Rollback plan
- Revert this commit.

------
https://chatgpt.com/codex/tasks/task_e_68b6445d43ac832f8742a57190937879