### PR TITLE
[Tests] ensure upload resets on Escape key

### DIFF
--- a/apps/web/src/app/new/page.test.tsx
+++ b/apps/web/src/app/new/page.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import UploadPage from './page';
 import { vi } from 'vitest';
 
@@ -17,3 +17,28 @@ it('opens file dialog when drop zone is clicked', () => {
 
   expect(clickSpy).toHaveBeenCalled();
 });
+
+it('resets to idle on escape key press during upload', () => {
+  vi.useFakeTimers();
+  const { getByRole, container } = render(<UploadPage />);
+  const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+  const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+
+  act(() => {
+    fireEvent.change(input, { target: { files: [file] } });
+    vi.advanceTimersByTime(1000);
+  });
+
+  const progressBeforeReset = container.querySelector('.bg-blue-600');
+  expect(progressBeforeReset).not.toBeNull();
+
+  act(() => {
+    fireEvent.keyDown(window, { key: 'Escape' });
+  });
+
+  const dropzoneAfterReset = getByRole('button', { name: /drag and drop area or click to select a file/i });
+  expect(dropzoneAfterReset).not.toBeNull();
+  expect(container.querySelector('.bg-blue-600')).toBeNull();
+  vi.useRealTimers();
+});
+


### PR DESCRIPTION
## What changed
- cover Escape key handling with a unit test for the Upload page

## Why (risk, user impact)
- guards against regressions when cancelling an in-progress upload

## Tests & Evidence
- `pnpm -C apps/web install --frozen-lockfile`
- `pnpm -C apps/web lint`
- `pnpm -C apps/web typecheck`
- `pnpm -C apps/web test run`
- `pnpm -C apps/web build`

## Migration note (alembic)
- none

## Rollback plan
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68b643d43374832fa731ca6ed3b387f8