### PR TITLE
[API] read stored analysis files

### DIFF
--- a/apps/api/blackletter_api/services/storage.py
+++ b/apps/api/blackletter_api/services/storage.py
@@ -137,10 +137,23 @@ def list_analyses_summaries(limit: int = 50) -> List[AnalysisSummary]:
 
 
 def get_analysis_text(analysis_id: str) -> str:
-    """Placeholder retrieval of analysis text."""
-    return ""
+    """Return stored analysis text or an empty string if missing."""
+    p = analysis_dir(analysis_id) / "text.txt"
+    try:
+        return p.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ""
+    except Exception:
+        return ""
 
 
 def get_analysis_findings(analysis_id: str) -> list:
-    """Placeholder retrieval of analysis findings."""
-    return []
+    """Return deserialized findings or an empty list if missing/invalid."""
+    p = analysis_dir(analysis_id) / "findings.json"
+    if not p.exists():
+        return []
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+        return data if isinstance(data, list) else []
+    except Exception:
+        return []

--- a/apps/api/blackletter_api/tests/unit/test_storage.py
+++ b/apps/api/blackletter_api/tests/unit/test_storage.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from blackletter_api.services import storage
+
+
+def test_get_analysis_text_reads_file(tmp_path: Path, monkeypatch) -> None:
+    base = tmp_path / "data"
+    monkeypatch.setattr(storage, "DATA_ROOT", base)
+    analysis_id = "a1"
+    analysis_path = storage.analysis_dir(analysis_id)
+    (analysis_path / "text.txt").write_text("hello", encoding="utf-8")
+
+    assert storage.get_analysis_text(analysis_id) == "hello"
+
+
+def test_get_analysis_text_missing_file(tmp_path: Path, monkeypatch) -> None:
+    base = tmp_path / "data"
+    monkeypatch.setattr(storage, "DATA_ROOT", base)
+
+    assert storage.get_analysis_text("missing") == ""
+
+
+def test_get_analysis_findings_reads_json(tmp_path: Path, monkeypatch) -> None:
+    base = tmp_path / "data"
+    monkeypatch.setattr(storage, "DATA_ROOT", base)
+    analysis_id = "b2"
+    analysis_path = storage.analysis_dir(analysis_id)
+    findings = [{"id": 1}]
+    (analysis_path / "findings.json").write_text(
+        json.dumps(findings), encoding="utf-8"
+    )
+
+    assert storage.get_analysis_findings(analysis_id) == findings
+
+
+def test_get_analysis_findings_missing_file(tmp_path: Path, monkeypatch) -> None:
+    base = tmp_path / "data"
+    monkeypatch.setattr(storage, "DATA_ROOT", base)
+
+    assert storage.get_analysis_findings("missing") == []
+


### PR DESCRIPTION
## What changed
- load analysis text and findings from persisted files
- unit tests for read success and missing files

## Why (risk, user impact)
- enables API to return saved analyses while handling absent data gracefully

## Tests & Evidence
- `pip install -r apps/api/requirements.txt`
- `pytest -q apps/api` *(fails: AttributeError: module 'blackletter_api.routers.rules' has no attribute 'router')*
- `pytest -q apps/api/blackletter_api/tests/unit/test_storage.py`

## Migration note (alembic)
- none

## Rollback plan
- revert this commit


------
https://chatgpt.com/codex/tasks/task_e_68b64401c5dc832fa2ae86bb3a0d7c6d