### PR TITLE
[API] add celery job queue for contract processing

### DIFF
--- a/apps/api/blackletter_api/services/celery_app.py
+++ b/apps/api/blackletter_api/services/celery_app.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import os
+from celery import Celery
+
+celery_app = Celery(
+    "blackletter_api",
+    broker=os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0"),
+    backend=os.getenv("CELERY_RESULT_BACKEND", "redis://localhost:6379/0"),
+)

--- a/apps/api/blackletter_api/tests/integration/test_job_queue.py
+++ b/apps/api/blackletter_api/tests/integration/test_job_queue.py
@@ -1,0 +1,28 @@
+import fakeredis
+from io import BytesIO
+from fastapi.testclient import TestClient
+
+from blackletter_api.main import app
+import blackletter_api.services.tasks as tasks
+
+client = TestClient(app)
+
+
+def test_upload_enqueues_job(monkeypatch):
+    monkeypatch.setattr(tasks, "redis_client", fakeredis.FakeRedis(decode_responses=True))
+    called = {}
+
+    def fake_delay(job_id, analysis_id, filename, size):
+        called["args"] = (job_id, analysis_id, filename, size)
+
+    monkeypatch.setattr(tasks.process_job, "delay", fake_delay)
+
+    files = {"file": ("doc.pdf", BytesIO(b"data"), "application/pdf")}
+    resp = client.post("/api/contracts", files=files)
+    assert resp.status_code == 201, resp.text
+    assert "args" in called
+    job_id, analysis_id, filename, size = called["args"]
+    data = resp.json()
+    assert job_id == data["id"]
+    assert analysis_id == data["analysis_id"]
+    assert filename.endswith(".pdf")

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,2 +1,5 @@
 fastapi
 uvicorn
+celery
+redis
+fakeredis


### PR DESCRIPTION
## What changed
- Introduced Celery + Redis queue for contract processing
- Persist job metadata in Redis for status polling
- Added integration tests for job queue and lifecycle

## Why (risk, user impact)
- Enables scalable async processing instead of background tasks
- Allows clients to poll reliable job status
- Risk: low; isolated to job orchestration

## Tests & Evidence
- `pip install -r apps/api/requirements.txt`
- `pytest -q apps/api` *(fails: module 'blackletter_api.routers.rules' has no attribute 'router')*

## Migration note
- none

## Rollback plan
- revert this PR


------
https://chatgpt.com/codex/tasks/task_e_68b644072488832f8be68004f30471f9