### PR TITLE
[UI] stream upload progress via WebSocket

### DIFF
--- a/apps/web/src/app/new/page.test.tsx
+++ b/apps/web/src/app/new/page.test.tsx
@@ -1,15 +1,26 @@
 import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
-import UploadPage from './page';
 import { vi } from 'vitest';
+import UploadPage from './page';
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
+const originalFetch = global.fetch;
+const originalWebSocket = global.WebSocket;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  global.fetch = originalFetch;
+  global.WebSocket = originalWebSocket as any;
+});
+
 it('opens file dialog when drop zone is clicked', () => {
   const { getByRole, container } = render(<UploadPage />);
-  const dropzone = getByRole('button', { name: /drag and drop area or click to select a file/i });
+  const dropzone = getByRole('button', {
+    name: /drag and drop area or click to select a file/i,
+  });
   const input = container.querySelector('input[type="file"]') as HTMLInputElement;
   const clickSpy = vi.spyOn(input, 'click');
 
@@ -18,15 +29,30 @@ it('opens file dialog when drop zone is clicked', () => {
   expect(clickSpy).toHaveBeenCalled();
 });
 
-it('resets to idle on escape key press during upload', () => {
-  vi.useFakeTimers();
+it('resets to idle on escape key press during upload', async () => {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ analysis_id: '1' }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+  global.fetch = fetchMock as any;
+
+  class MockWebSocket {
+    static instances: MockWebSocket[] = [];
+    onmessage: ((ev: any) => void) | null = null;
+    onerror: ((ev: any) => void) | null = null;
+    close = vi.fn();
+    constructor(url: string) {
+      MockWebSocket.instances.push(this);
+    }
+  }
+  (global as any).WebSocket = MockWebSocket as any;
+
   const { getByRole, container } = render(<UploadPage />);
   const input = container.querySelector('input[type="file"]') as HTMLInputElement;
   const file = new File(['content'], 'test.txt', { type: 'text/plain' });
 
-  act(() => {
+  await act(async () => {
     fireEvent.change(input, { target: { files: [file] } });
-    vi.advanceTimersByTime(1000);
   });
 
   const progressBeforeReset = container.querySelector('.bg-blue-600');
@@ -36,9 +62,54 @@ it('resets to idle on escape key press during upload', () => {
     fireEvent.keyDown(window, { key: 'Escape' });
   });
 
-  const dropzoneAfterReset = getByRole('button', { name: /drag and drop area or click to select a file/i });
+  const dropzoneAfterReset = getByRole('button', {
+    name: /drag and drop area or click to select a file/i,
+  });
   expect(dropzoneAfterReset).not.toBeNull();
   expect(container.querySelector('.bg-blue-600')).toBeNull();
-  vi.useRealTimers();
+});
+
+it('updates progress based on websocket messages', async () => {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ analysis_id: 'analysis-1' }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+  global.fetch = fetchMock as any;
+
+  class MockWebSocket {
+    static instances: MockWebSocket[] = [];
+    onmessage: ((ev: any) => void) | null = null;
+    onerror: ((ev: any) => void) | null = null;
+    close = vi.fn();
+    constructor(url: string) {
+      MockWebSocket.instances.push(this);
+    }
+  }
+  (global as any).WebSocket = MockWebSocket as any;
+
+  const { container, getByRole } = render(<UploadPage />);
+  const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+  const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+
+  await act(async () => {
+    fireEvent.change(input, { target: { files: [file] } });
+  });
+
+  const wsInstance = MockWebSocket.instances[0];
+
+  act(() => {
+    wsInstance.onmessage?.({
+      data: JSON.stringify({ step: 'extracting', progress: 25 }),
+    });
+  });
+  expect(container.querySelector('.bg-blue-600')?.getAttribute('style')).toContain('width: 25%');
+
+  act(() => {
+    wsInstance.onmessage?.({
+      data: JSON.stringify({ step: 'done', progress: 100 }),
+    });
+  });
+
+  expect(getByRole('button', { name: /view findings/i })).not.toBeNull();
 });
 

--- a/apps/web/src/app/new/page.tsx
+++ b/apps/web/src/app/new/page.tsx
@@ -11,42 +11,63 @@ const UploadPage = () => {
     'idle' | 'queued' | 'extracting' | 'detecting' | 'reporting' | 'done'
   >('idle');
   const [progress, setProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const wsRef = useRef<WebSocket | null>(null);
 
-  // Mock state machine logic
-  useEffect(() => {
-    let timer: NodeJS.Timeout;
-    if (uploadStep !== 'idle' && uploadStep !== 'done') {
-      timer = setTimeout(() => {
-        switch (uploadStep) {
-          case 'queued':
-            setUploadStep('extracting');
-            setProgress(25);
-            break;
-          case 'extracting':
-            setUploadStep('detecting');
-            setProgress(50);
-            break;
-          case 'detecting':
-            setUploadStep('reporting');
-            setProgress(75);
-            break;
-          case 'reporting':
-            setUploadStep('done');
-            setProgress(100);
-            break;
-          default:
-            break;
-        }
-      }, 900); // ~0.9s per step
-    }
-    return () => clearTimeout(timer);
-  }, [uploadStep]);
-
-  const handleFileChange = (selectedFile: File) => {
+  const handleFileChange = async (selectedFile: File) => {
     setFile(selectedFile);
     setUploadStep('queued');
     setProgress(0);
+    setError(null);
+
+    try {
+      const intakeRes = await fetch('/api/intake', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ filename: selectedFile.name }),
+      });
+      if (!intakeRes.ok) throw new Error('intake_failed');
+      const { analysis_id } = await intakeRes.json();
+
+      const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+      const ws = new WebSocket(
+        `${protocol}://${window.location.host}/ws/analysis/${analysis_id}`
+      );
+      wsRef.current = ws;
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data.step) {
+            setUploadStep(data.step);
+          }
+          if (typeof data.progress === 'number') {
+            setProgress(data.progress);
+          }
+        } catch {
+          /* ignore malformed events */
+        }
+      };
+      ws.onerror = () => {
+        setError('Connection error');
+        handleReset();
+      };
+
+      const formData = new FormData();
+      formData.append('file', selectedFile);
+      const uploadRes = await fetch(`/api/analyses/${analysis_id}/file`, {
+        method: 'POST',
+        body: formData,
+      });
+      if (!uploadRes.ok) throw new Error('upload_failed');
+    } catch (e) {
+      setError('Upload failed');
+      wsRef.current?.close();
+      wsRef.current = null;
+      setFile(null);
+      setUploadStep('idle');
+      setProgress(0);
+    }
   };
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
@@ -73,14 +94,23 @@ const UploadPage = () => {
   };
 
   const handleReset = useCallback(() => {
+    wsRef.current?.close();
+    wsRef.current = null;
     setFile(null);
     setUploadStep('idle');
     setProgress(0);
+    setError(null);
   }, []);
 
   const handleViewFindings = () => {
     router.push('/analyses/mock-1');
   };
+
+  useEffect(() => {
+    return () => {
+      wsRef.current?.close();
+    };
+  }, []);
 
   // Cancel simulation on ESC key
   useEffect(() => {
@@ -207,7 +237,10 @@ const UploadPage = () => {
             )}
           </div>
         )}
-        {file && uploadStep === 'idle' && (
+        {error && (
+          <p className="mt-4 text-sm text-red-600 text-center">{error}</p>
+        )}
+        {file && uploadStep === 'idle' && !error && (
           <p className="mt-4 text-sm text-gray-500 text-center">
             Selected file: {file.name}
           </p>


### PR DESCRIPTION
## What changed
- Trigger `/api/intake` on file select and stream progress from `/ws/analysis/{id}`
- Upload selected file to backend and surface error state

## Why (risk, user impact)
- Gives users real-time feedback during analysis upload; low risk

## Tests & Evidence
- `pnpm -C apps/web lint`
- `pnpm -C apps/web typecheck`
- `pnpm -C apps/web test run`
- `pnpm -C apps/web build`

## Migration note (alembic)
- none

## Rollback plan
- revert commit

------
https://chatgpt.com/codex/tasks/task_e_68b66da670a8832fa3d20fb09dadabc4