### PR TITLE
[API] standardize error handling

### DIFF
--- a/apps/api/blackletter_api/main.py
+++ b/apps/api/blackletter_api/main.py
@@ -9,7 +9,13 @@ import uuid
 import logging
 import time
 import json
-from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
+from fastapi import (
+    FastAPI,
+    HTTPException,
+    Request,
+    WebSocket,
+    WebSocketDisconnect,
+)
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List
@@ -90,6 +96,18 @@ app = FastAPI(
     description="API for GDPR contract analysis.",
     version="0.1.0"
 )
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    """Return errors in a consistent JSON envelope."""
+
+    if isinstance(exc.detail, dict):
+        return JSONResponse(status_code=exc.status_code, content=exc.detail)
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"code": "error", "message": str(exc.detail)},
+    )
 
 
 @app.middleware("http")

--- a/apps/api/blackletter_api/models/schemas.py
+++ b/apps/api/blackletter_api/models/schemas.py
@@ -8,6 +8,13 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 
 
+class ErrorResponse(BaseModel):
+    """Standard error envelope for API responses."""
+
+    code: str
+    message: str
+
+
 class ExtractionArtifact(BaseModel):
     analysis_id: UUID
     text_path: str

--- a/apps/api/blackletter_api/routers/analyses.py
+++ b/apps/api/blackletter_api/routers/analyses.py
@@ -79,7 +79,10 @@ def get_analysis_summary(analysis_id: str) -> AnalysisSummary:
         coverage = compute_analysis_coverage(analysis_id, findings_list)
         
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail="not_found") from exc
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "not_found", "message": "Analysis not found"},
+        ) from exc
     
     return AnalysisSummary(
         id=rec.id,
@@ -97,5 +100,8 @@ def get_analysis_findings(analysis_id: str) -> List[Finding]:
     try:
         rec_findings = orchestrator.findings(analysis_id)
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail="not_found") from exc
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "not_found", "message": "Analysis not found"},
+        ) from exc
     return [Finding(**f) for f in rec_findings]

--- a/apps/api/blackletter_api/routers/contracts.py
+++ b/apps/api/blackletter_api/routers/contracts.py
@@ -48,7 +48,13 @@ async def upload_contract(
         elif lower.endswith(".docx"):
             ext = ".docx"
     if ext is None:
-        raise HTTPException(status_code=415, detail="unsupported_file_type")
+        raise HTTPException(
+            status_code=415,
+            detail={
+                "code": "unsupported_file_type",
+                "message": "Only PDF or DOCX files are supported.",
+            },
+        )
 
     # Create the analysis record in the database
     analysis = Analysis(
@@ -74,10 +80,22 @@ async def upload_contract(
         db.commit()
     except ValueError as e:
         if str(e) == "file_too_large":
-            raise HTTPException(status_code=413, detail="file_too_large")
+            raise HTTPException(
+                status_code=413,
+                detail={
+                    "code": "file_too_large",
+                    "message": "File exceeds 10MB limit.",
+                },
+            )
         raise
     except OSError as e:
-        raise HTTPException(status_code=500, detail="disk_io_error") from e
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "code": "disk_io_error",
+                "message": "Could not save uploaded file.",
+            },
+        ) from e
 
     job_id = new_job(analysis_id=analysis_id)
 

--- a/apps/api/blackletter_api/routers/jobs.py
+++ b/apps/api/blackletter_api/routers/jobs.py
@@ -13,7 +13,10 @@ router = APIRouter(tags=["jobs"])
 def get_job_status(job_id: str) -> JobStatus:
     job = get_job(job_id)
     if not job:
-        raise HTTPException(status_code=404, detail="not_found")
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "not_found", "message": "Job not found"},
+        )
     return JobStatus(
         id=job.id,
         job_id=job.id,

--- a/apps/api/blackletter_api/tests/unit/test_analyses_router.py
+++ b/apps/api/blackletter_api/tests/unit/test_analyses_router.py
@@ -20,12 +20,16 @@ def test_analysis_summary_not_found():
     orchestrator._store.clear()
     res = client.get("/api/analyses/missing")
     assert res.status_code == 404
-    assert res.json()["detail"] == "not_found"
+    body = res.json()
+    assert body["code"] == "not_found"
+    assert isinstance(body["message"], str)
 
 
 def test_analysis_findings_not_found():
     orchestrator._store.clear()
     res = client.get("/api/analyses/missing/findings")
     assert res.status_code == 404
-    assert res.json()["detail"] == "not_found"
+    body = res.json()
+    assert body["code"] == "not_found"
+    assert isinstance(body["message"], str)
 

--- a/apps/api/blackletter_api/tests/unit/test_contracts_validation.py
+++ b/apps/api/blackletter_api/tests/unit/test_contracts_validation.py
@@ -31,14 +31,18 @@ def test_upload_missing_file():
 def test_upload_unsupported_type(name: str, ctype: str):
     res = _post_upload(name, ctype, b"hello")
     assert res.status_code == 415
-    assert res.json()["detail"] == "unsupported_file_type"
+    body = res.json()
+    assert body["code"] == "unsupported_file_type"
+    assert isinstance(body["message"], str)
 
 
 def test_upload_too_large_triggers_413():
     big = b"x" * (10 * 1024 * 1024 + 1)
     res = _post_upload("big.pdf", "application/pdf", big)
     assert res.status_code == 413
-    assert res.json()["detail"] == "file_too_large"
+    body = res.json()
+    assert body["code"] == "file_too_large"
+    assert isinstance(body["message"], str)
 
 
 def test_contract_validation_status_schema():

--- a/apps/api/blackletter_api/tests/unit/test_jobs_router.py
+++ b/apps/api/blackletter_api/tests/unit/test_jobs_router.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+
+from blackletter_api.main import app
+
+
+client = TestClient(app)
+
+
+def test_job_not_found():
+    res = client.get("/api/jobs/missing")
+    assert res.status_code == 404
+    body = res.json()
+    assert body["code"] == "not_found"
+    assert isinstance(body["message"], str)

--- a/docs/api-architecture.md
+++ b/docs/api-architecture.md
@@ -27,7 +27,8 @@ Describes RESTful contract for Blackletter services and how clients interact wit
 
 ## Error Handling
 
-- Consistent JSON envelope: `{ "detail": str, "code": str }`.
+- Consistent JSON envelope: `{ "code": str, "message": str }`.
+- `code` provides a stable machine-readable identifier while `message` is human-readable.
 - 4xx for client issues, 5xx for server faults.
 
 ## Rate Limits


### PR DESCRIPTION
## What changed
- add `ErrorResponse` schema and global HTTP exception handler
- return `code` and `message` in contract, job, and analysis errors
- exercise standardized errors in unit tests
- document common error envelope

## Why (risk, user impact)
Creates consistent error structure for clients and simplifies downstream handling.

## Tests & Evidence
- `pip install -r apps/api/requirements.txt`
- `SECRET_KEY=test pytest -q apps/api` *(fails: Could not determine join condition between tables)*
- `SECRET_KEY=test pytest -q apps/api/blackletter_api/tests/unit/test_jobs_router.py::test_job_not_found`

## Migration note
none

## Rollback plan
Revert this PR.


------
https://chatgpt.com/codex/tasks/task_e_68b66d6558f8832f802875a1415b89a9