### PR TITLE
fix(web): keep upload dropzone full-width

### DIFF
--- a/apps/web/src/app/new/page.tsx
+++ b/apps/web/src/app/new/page.tsx
@@ -114,7 +114,7 @@ const UploadPage = () => {
           <>
             <label
               htmlFor="fileInput"
-              className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
+              className={`block w-full border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
                 isDragging ? 'border-blue-500 bg-blue-50' : 'border-gray-300'
               }`}
               onDrop={handleDrop}


### PR DESCRIPTION
## Summary
- ensure upload label is block-level and spans full width

## Testing
- `pnpm -C apps/web lint`
- `pnpm -C apps/web test`
- `pnpm -C apps/web build`
- `pnpm -C apps/web typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b681537f38832f95e4d86bf0ef35c1