### PR TITLE
[UI] add findings drawer component

### DIFF
--- a/apps/web/src/components/FindingsDrawer.test.tsx
+++ b/apps/web/src/components/FindingsDrawer.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import FindingsDrawer from './FindingsDrawer';
+import { vi } from 'vitest';
+
+describe('FindingsDrawer', () => {
+  const finding = { rule: 'Rule 1', evidence: 'Some evidence', verdict: 'pass' };
+
+  it('renders when open', () => {
+    const { getByText } = render(
+      <FindingsDrawer open onClose={() => {}} finding={finding} />
+    );
+    expect(getByText(/Finding Details/)).toBeTruthy();
+  });
+
+  it('does not render when closed', () => {
+    const { queryByText } = render(
+      <FindingsDrawer open={false} onClose={() => {}} finding={finding} />
+    );
+    expect(queryByText(/Finding Details/)).toBeNull();
+  });
+
+  it('calls onClose on Escape key', () => {
+    const onClose = vi.fn();
+    render(<FindingsDrawer open onClose={onClose} finding={finding} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+

--- a/apps/web/src/components/FindingsDrawer.tsx
+++ b/apps/web/src/components/FindingsDrawer.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+
+interface FindingsDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  finding?: {
+    rule: string;
+    evidence: string;
+    verdict?: string;
+  } | null;
+}
+
+export default function FindingsDrawer({ open, onClose, finding }: FindingsDrawerProps) {
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      } else if (e.key === 'Tab' && drawerRef.current) {
+        const focusable = drawerRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+
+    if (open) {
+      drawerRef.current?.focus();
+      document.addEventListener('keydown', handleKeyDown);
+    }
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+      <div
+        ref={drawerRef}
+        tabIndex={-1}
+        className="absolute right-0 top-0 h-full w-80 bg-white p-6 shadow-lg space-y-4"
+      >
+        <div>
+          <h2 className="text-lg font-semibold mb-2">Finding Details</h2>
+          <p className="text-sm"><span className="font-medium">Rule:</span> {finding?.rule}</p>
+          <p className="text-sm"><span className="font-medium">Evidence:</span> {finding?.evidence}</p>
+          {finding?.verdict && (
+            <p className="text-sm"><span className="font-medium">Verdict:</span> {finding.verdict}</p>
+          )}
+        </div>
+        <div className="flex justify-end">
+          <button onClick={onClose} className="text-sm underline">Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/web/src/components/FindingsTable.tsx
+++ b/apps/web/src/components/FindingsTable.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import React, { useState } from 'react';
+import FindingsDrawer from './FindingsDrawer';
+
+interface Finding {
+  id: string;
+  rule: string;
+  evidence: string;
+  verdict: string;
+}
+
+interface FindingsTableProps {
+  findings: Finding[];
+}
+
+export default function FindingsTable({ findings }: FindingsTableProps) {
+  const [selected, setSelected] = useState<Finding | null>(null);
+  const handleClose = () => setSelected(null);
+
+  return (
+    <div className="space-y-4">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="bg-gray-50 text-left">
+            <th className="p-4 font-medium">Rule</th>
+            <th className="p-4 font-medium">Evidence</th>
+          </tr>
+        </thead>
+        <tbody>
+          {findings.map(f => (
+            <tr
+              key={f.id}
+              onClick={() => setSelected(f)}
+              className="cursor-pointer hover:bg-gray-50"
+            >
+              <td className="p-4">{f.rule}</td>
+              <td className="p-4">{f.evidence}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <FindingsDrawer open={!!selected} finding={selected} onClose={handleClose} />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## What changed
- add controlled `FindingsDrawer` with mock fields and focus management
- link drawer to `FindingsTable` for row selection

## Why (risk, user impact)
- reveals finding details in context to improve review flow
- risk: low, isolated frontend feature

## Tests & Evidence
- `pnpm -C apps/web lint`
- `pnpm -C apps/web test --run`
- `pnpm -C apps/web typecheck`
- `pnpm -C apps/web build`

## Migration note (alembic)
none

## Rollback plan
revert commit

cc @codex

------
https://chatgpt.com/codex/tasks/task_e_68b67f391ac0832f990e0ccad50f7031