### PR TITLE
[API] add report persistence

### DIFF
--- a/apps/api/blackletter_api/migrations/versions/c4b32e6c5a41_create_reports_table.py
+++ b/apps/api/blackletter_api/migrations/versions/c4b32e6c5a41_create_reports_table.py
@@ -1,0 +1,27 @@
+"""create reports table"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "c4b32e6c5a41"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "reports",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("analysis_id", sa.String(), nullable=False),
+        sa.Column("filename", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("options", sa.JSON(), nullable=False),
+    )
+    op.create_index(op.f("ix_reports_analysis_id"), "reports", ["analysis_id"])
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_reports_analysis_id"), table_name="reports")
+    op.drop_table("reports")

--- a/apps/api/blackletter_api/models/entities.py
+++ b/apps/api/blackletter_api/models/entities.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     Boolean,
     Float,
     Enum,
+    JSON,
     func,
 )
 from sqlalchemy.dialects.postgresql import UUID
@@ -88,6 +89,20 @@ class Metric(Base):
     
     def __repr__(self):
         return f"<Metric(id={self.id}, analysis_id={self.analysis_id}, tokens={self.tokens_per_doc}, llm={self.llm_invoked})>"
+
+
+# Report model matching ReportExport schema
+class Report(Base):
+    __tablename__ = "reports"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    analysis_id = Column(String, nullable=False, index=True)
+    filename = Column(String, nullable=False)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+    options = Column(JSON, nullable=False)
+
+    def __repr__(self):
+        return f"<Report(id={self.id}, analysis_id='{self.analysis_id}', filename='{self.filename}')>"
 
 
 # Story 5.1 - Organization Settings model

--- a/apps/api/blackletter_api/routers/reports.py
+++ b/apps/api/blackletter_api/routers/reports.py
@@ -1,32 +1,46 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import List
-from uuid import uuid4
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
 
+from .. import database
+from ..models.entities import Report
 from ..models.schemas import ReportExport, ExportOptions
 
 router = APIRouter(tags=["reports"])
 
-_exports: List[ReportExport] = []
-
 
 @router.get("/reports", response_model=List[ReportExport])
-def list_reports() -> List[ReportExport]:
-    return _exports
+def list_reports(db: Session = Depends(database.get_db)) -> List[ReportExport]:
+    reports = db.query(Report).order_by(Report.created_at.desc()).all()
+    return [
+        ReportExport(
+            id=str(r.id),
+            analysis_id=r.analysis_id,
+            filename=r.filename,
+            created_at=r.created_at.isoformat(),
+            options=ExportOptions(**r.options),
+        )
+        for r in reports
+    ]
 
 
 @router.post("/reports/{analysis_id}", response_model=ReportExport, status_code=status.HTTP_201_CREATED)
-def create_report(analysis_id: str, opts: ExportOptions) -> ReportExport:
-    rec = ReportExport(
-        id=str(uuid4()),
+def create_report(analysis_id: str, opts: ExportOptions, db: Session = Depends(database.get_db)) -> ReportExport:
+    report = Report(
         analysis_id=analysis_id,
         filename=f"{analysis_id.upper()}.pdf",
-        created_at=datetime.now(timezone.utc).isoformat(),
+        options=opts.dict(),
+    )
+    db.add(report)
+    db.commit()
+    db.refresh(report)
+    return ReportExport(
+        id=str(report.id),
+        analysis_id=report.analysis_id,
+        filename=report.filename,
+        created_at=report.created_at.isoformat(),
         options=opts,
     )
-    _exports.insert(0, rec)
-    del _exports[20:]
-    return rec

--- a/apps/api/blackletter_api/tests/integration/test_reports_persistence.py
+++ b/apps/api/blackletter_api/tests/integration/test_reports_persistence.py
@@ -1,0 +1,39 @@
+import os
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import uuid
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+
+from blackletter_api import database
+from blackletter_api.models.entities import Report
+from blackletter_api.routers.reports import router as reports_router
+
+app = FastAPI()
+app.include_router(reports_router, prefix="/api")
+
+client = TestClient(app)
+
+
+def test_create_report_persists_to_db():
+    # ensure table clean
+    db = database.SessionLocal()
+    try:
+        db.query(Report).delete()
+        db.commit()
+    finally:
+        db.close()
+
+    payload = {"include_logo": False, "include_meta": True, "date_format": "ISO"}
+    res = client.post("/api/reports/sample", json=payload)
+    assert res.status_code == 201
+    data = res.json()
+
+    db = database.SessionLocal()
+    try:
+        report = db.query(Report).filter_by(id=uuid.UUID(data["id"])).first()
+        assert report is not None
+        assert report.analysis_id == "sample"
+        assert report.options["date_format"] == "ISO"
+    finally:
+        db.close()


### PR DESCRIPTION
## What changed
- add `Report` SQLAlchemy model and migration
- persist report exports via database instead of in-memory list
- add unit/integration tests verifying report storage

## Why (risk, user impact)
- enables durable storage of generated reports for later retrieval
- moderate risk: new table and DB writes

## Tests & Evidence
- `pip install -r apps/api/requirements.txt`
- `SECRET_KEY=test-secret pytest apps/api/blackletter_api/tests/unit/test_reports_endpoints.py -q`
- `SECRET_KEY=test-secret pytest apps/api/blackletter_api/tests/integration/test_reports_persistence.py -q`
- `alembic upgrade head` *(fails: No config file 'alembic.ini' found)*

## Migration note (alembic)
- c4b32e6c5a41

## Rollback plan
- `alembic downgrade -1` to drop `reports` table and revert code changes


------
https://chatgpt.com/codex/tasks/task_e_68b67f6bfe80832f944a69da43ee4574