### PR TITLE
[API] persist job state in database

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ uvicorn blackletter_api.main:app --reload
 > remains process-local. Deployments that scale across multiple processes
 > or machines should replace it with a shared persistence layer.
 
+### Background Worker
+
+Start the Celery worker to process jobs asynchronously:
+
+```bash
+cd apps/api
+celery -A blackletter_api.services.tasks.celery_app worker --loglevel=info
+```
+
 ### Frontend (Ready for Development)
 ```bash
 cd apps/web

--- a/apps/api/alembic.ini
+++ b/apps/api/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = apps/api/migrations
+sqlalchemy.url = sqlite:///test.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/apps/api/blackletter_api/models/entities.py
+++ b/apps/api/blackletter_api/models/entities.py
@@ -45,6 +45,22 @@ class Analysis(Base):
         return f"<Analysis(id={self.id}, filename='{self.filename}', status='{self.status}')>"
 
 
+class Job(Base):
+    __tablename__ = "jobs"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    analysis_id = Column(UUID(as_uuid=True), nullable=True, index=True)
+    status = Column(String, nullable=False, default="queued")
+    error_reason = Column(String, nullable=True)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+    updated_at = Column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    def __repr__(self):
+        return f"<Job(id={self.id}, status='{self.status}')>"
+
+
 # Minimal Document model with tenancy scope
 class Document(Base):
     __tablename__ = "documents"

--- a/apps/api/blackletter_api/routers/contracts.py
+++ b/apps/api/blackletter_api/routers/contracts.py
@@ -75,7 +75,7 @@ async def upload_contract(
     except OSError as e:
         raise HTTPException(status_code=500, detail="disk_io_error") from e
 
-    job_id = new_job(analysis_id=analysis_id)
+    job_id = new_job(db, analysis_id=analysis_id)
     process_job.delay(job_id, analysis_id, safe_name, size)
 
     return JobStatus(

--- a/apps/api/blackletter_api/routers/jobs.py
+++ b/apps/api/blackletter_api/routers/jobs.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
 
+from ..database import get_db
 from ..models.schemas import JobStatus
 from ..services.tasks import get_job
 
@@ -10,8 +12,8 @@ router = APIRouter(tags=["jobs"])
 
 
 @router.get("/jobs/{job_id}", response_model=JobStatus)
-def get_job_status(job_id: str) -> JobStatus:
-    job = get_job(job_id)
+def get_job_status(job_id: str, db: Session = Depends(get_db)) -> JobStatus:
+    job = get_job(db, job_id)
     if not job:
         raise HTTPException(status_code=404, detail="not_found")
     return JobStatus(

--- a/apps/api/blackletter_api/services/gemini_service.py
+++ b/apps/api/blackletter_api/services/gemini_service.py
@@ -76,3 +76,6 @@ class GeminiService:
         resp = self.client.generate_content([{"text": f"Summarize:\n{text}"}])  # type: ignore[attr-defined]
         return getattr(resp, "text", str(resp))
 
+
+gemini_service = GeminiService()
+

--- a/apps/api/blackletter_api/services/rulepack_loader.py
+++ b/apps/api/blackletter_api/services/rulepack_loader.py
@@ -4,6 +4,10 @@ from pathlib import Path
 from typing import Dict, List, Any
 import yaml
 
+
+class RulepackError(Exception):
+    """Raised when rulepack loading fails."""
+
 # repo root is two levels up from services; adjust to find bundled rules
 BASE_DIR = Path(__file__).resolve().parents[1]
 RULES_DIR = BASE_DIR / "rules"

--- a/apps/api/blackletter_api/services/weak_lexicon.py
+++ b/apps/api/blackletter_api/services/weak_lexicon.py
@@ -31,3 +31,15 @@ def get_counter_anchors() -> List[str]:
     anchors = list(lex.strengtheners or [])
     return anchors or DEFAULT_STRENGTHENERS.copy()
 
+
+def get_weak_terms_with_metadata() -> List[tuple[str, str]]:
+    """Return weak terms paired with category metadata."""
+    lex = _load()
+    if not lex:
+        return [(t, "default") for t in DEFAULT_WEAK_TERMS]
+    pairs = []
+    pairs += [(t, "hedging") for t in lex.hedging]
+    pairs += [(t, "discretionary") for t in lex.discretionary]
+    pairs += [(t, "vague") for t in lex.vague]
+    return pairs or [(t, "default") for t in DEFAULT_WEAK_TERMS]
+

--- a/apps/api/blackletter_api/tests/conftest.py
+++ b/apps/api/blackletter_api/tests/conftest.py
@@ -9,11 +9,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 # Ensure AUTH_PEPPER is available for tests
 os.environ.setdefault("AUTH_PEPPER", "test-pepper")
+os.environ.setdefault("SECRET_KEY", "test-secret")
 
 @pytest.fixture(autouse=True)
 def auth_pepper_env(monkeypatch) -> None:
     """Provide a default AUTH_PEPPER for tests via environment."""
     monkeypatch.setenv("AUTH_PEPPER", "test-pepper")
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
 
 from sqlalchemy import create_engine
 

--- a/apps/api/blackletter_api/tests/integration/test_job_lifecycle.py
+++ b/apps/api/blackletter_api/tests/integration/test_job_lifecycle.py
@@ -2,7 +2,6 @@ import json
 from io import BytesIO
 from pathlib import Path
 
-import fakeredis
 from fastapi.testclient import TestClient
 
 from blackletter_api.main import app
@@ -17,7 +16,6 @@ def test_job_lifecycle_sync(monkeypatch):
     # Force synchronous processing for deterministic test
     tasks.celery_app.conf.task_always_eager = True
     tasks.celery_app.conf.task_eager_propagates = True
-    monkeypatch.setattr(tasks, "redis_client", fakeredis.FakeRedis(decode_responses=True))
 
     # Mock run_extraction to provide controlled extraction data
     mock_extraction_data = {

--- a/apps/api/blackletter_api/tests/integration/test_job_persistence.py
+++ b/apps/api/blackletter_api/tests/integration/test_job_persistence.py
@@ -1,0 +1,22 @@
+from io import BytesIO
+from fastapi.testclient import TestClient
+
+from blackletter_api.main import app
+import blackletter_api.services.tasks as tasks
+
+
+def test_job_persists_across_restarts(monkeypatch):
+    monkeypatch.setattr(tasks.process_job, "delay", lambda *a, **k: None)
+    client = TestClient(app)
+    files = {"file": ("doc.pdf", BytesIO(b"data"), "application/pdf")}
+    resp = client.post("/api/contracts", files=files)
+    assert resp.status_code == 201
+    job_id = resp.json()["id"]
+    client.close()
+
+    new_client = TestClient(app)
+    status = new_client.get(f"/api/jobs/{job_id}")
+    assert status.status_code == 200
+    data = status.json()
+    assert data["id"] == job_id
+    assert data["status"] == "queued"

--- a/apps/api/blackletter_api/tests/integration/test_job_polling_status.py
+++ b/apps/api/blackletter_api/tests/integration/test_job_polling_status.py
@@ -1,7 +1,5 @@
 import time
 from io import BytesIO
-
-import fakeredis
 from fastapi.testclient import TestClient
 
 from blackletter_api.main import app
@@ -19,7 +17,6 @@ def _post_upload_ok():
 def test_job_polling_async_success(monkeypatch):
     tasks.celery_app.conf.task_always_eager = True
     tasks.celery_app.conf.task_eager_propagates = True
-    monkeypatch.setattr(tasks, "redis_client", fakeredis.FakeRedis(decode_responses=True))
 
     resp = _post_upload_ok()
     assert resp.status_code == 201, resp.text
@@ -49,7 +46,6 @@ def test_job_polling_error(monkeypatch):
     # Force synchronous execution and simulate extraction failure
     tasks.celery_app.conf.task_always_eager = True
     tasks.celery_app.conf.task_eager_propagates = True
-    monkeypatch.setattr(tasks, "redis_client", fakeredis.FakeRedis(decode_responses=True))
 
     def boom(*args, **kwargs):  # noqa: ANN001
         raise RuntimeError("boom")

--- a/apps/api/blackletter_api/tests/integration/test_job_queue.py
+++ b/apps/api/blackletter_api/tests/integration/test_job_queue.py
@@ -9,7 +9,6 @@ client = TestClient(app)
 
 
 def test_upload_enqueues_job(monkeypatch):
-    monkeypatch.setattr(tasks, "redis_client", fakeredis.FakeRedis(decode_responses=True))
     called = {}
 
     def fake_delay(job_id, analysis_id, filename, size):

--- a/apps/api/migrations/env.py
+++ b/apps/api/migrations/env.py
@@ -1,0 +1,37 @@
+import os
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from blackletter_api.database import Base
+from blackletter_api.models import entities  # noqa: F401
+
+config = context.config
+if os.environ.get("DATABASE_URL"):
+    config.set_main_option("sqlalchemy.url", os.environ["DATABASE_URL"])
+
+fileConfig(config.config_file_name)
+target_metadata = Base.metadata
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/apps/api/migrations/versions/0001_create_jobs_table.py
+++ b/apps/api/migrations/versions/0001_create_jobs_table.py
@@ -1,0 +1,27 @@
+"""add jobs table"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+import uuid
+
+# revision identifiers, used by Alembic.
+revision = "0001_create_jobs_table"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "jobs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, default=uuid.uuid4),
+        sa.Column("analysis_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("error_reason", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("jobs")

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -3,3 +3,5 @@ uvicorn
 celery
 redis
 fakeredis
+sqlalchemy
+alembic


### PR DESCRIPTION
## What changed
- add Job ORM model and Alembic migration
- persist job status via SQLAlchemy and expose DB-backed job lookup
- document Celery worker startup
- add tests for job persistence across restarts

## Why (risk, user impact)
- durable job records survive process crashes and allow reliable status polling

## Tests & Evidence
- `pip install -r apps/api/requirements.txt`
- `SECRET_KEY=test PYTHONPATH=apps/api alembic -c apps/api/alembic.ini upgrade head`
- `pytest -q apps/api` *(fails: ModuleNotFoundError: No module named 'passlib')*

## Migration note (alembic)
- 0001_create_jobs_table

## Rollback plan
- revert this PR and run `alembic downgrade -1`

------
https://chatgpt.com/codex/tasks/task_e_68b67f6c9fb4832fa9e1abde5e5aef95