### PR TITLE
[API] standardize error responses

### DIFF
--- a/apps/api/blackletter_api/tests/unit/test_contracts_validation.py
+++ b/apps/api/blackletter_api/tests/unit/test_contracts_validation.py
@@ -31,14 +31,18 @@ def test_upload_missing_file():
 def test_upload_unsupported_type(name: str, ctype: str):
     res = _post_upload(name, ctype, b"hello")
     assert res.status_code == 415
-    assert res.json()["detail"] == "unsupported_file_type"
+    data = res.json()
+    assert data["code"] == "unsupported_file_type"
+    assert data["detail"] == "Unsupported file type"
 
 
 def test_upload_too_large_triggers_413():
     big = b"x" * (10 * 1024 * 1024 + 1)
     res = _post_upload("big.pdf", "application/pdf", big)
     assert res.status_code == 413
-    assert res.json()["detail"] == "file_too_large"
+    data = res.json()
+    assert data["code"] == "file_too_large"
+    assert data["detail"] == "File too large"
 
 
 def test_contract_validation_status_schema():

--- a/docs/stories/EPIC1-STORY1.1.md
+++ b/docs/stories/EPIC1-STORY1.1.md
@@ -12,8 +12,8 @@
 
 ## Acceptance Criteria:
 * The endpoint accepts a file and responds `201 Created` with JSON `{ "job_id": "uuid", "analysis_id": "uuid", "status": "queued" }`.
-* If the file exceeds 10MB, respond `413 Payload Too Large` with `{ "detail": "file_too_large" }`.
-* If the file is not a PDF/DOCX, respond `415 Unsupported Media Type` with `{ "detail": "unsupported_file_type" }`.
+* If the file exceeds 10MB, respond `413 Payload Too Large` with `{ "code": "file_too_large", "detail": "File too large" }`.
+* If the file is not a PDF/DOCX, respond `415 Unsupported Media Type` with `{ "code": "unsupported_file_type", "detail": "Unsupported file type" }`.
 
 ## Test Fixtures:
 * **Success Case:** Upload `test_fixture_1.docx` (50KB, valid).


### PR DESCRIPTION
## Summary
- update contract upload tests to assert `code` and `detail` fields
- stub background job creation in integration tests to avoid Redis/Celery
- document new error envelope in Story 1.1

## Testing
- `AUTH_PEPPER=test pytest -q apps/api/blackletter_api/tests/unit/test_contracts_validation.py apps/api/blackletter_api/tests/integration/test_upload_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6852433c0832f843255b724964d63