### PR TITLE
[UI] add copy button to EvidenceDrawer

### DIFF
--- a/apps/web/src/components/EvidenceDrawer.test.tsx
+++ b/apps/web/src/components/EvidenceDrawer.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen, act } from '@testing-library/react';
 import EvidenceDrawer from './EvidenceDrawer';
 import { vi } from 'vitest';
 
@@ -13,5 +13,26 @@ describe('EvidenceDrawer', () => {
     );
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('copies snippet text and shows toast', async () => {
+    vi.useFakeTimers();
+    const writeText = vi.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(
+      <EvidenceDrawer isOpen onClose={vi.fn()}>
+        <p>snippet text</p>
+      </EvidenceDrawer>
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByText('Copy'));
+    });
+    expect(writeText).toHaveBeenCalledWith('snippet text');
+    expect(screen.getByText('Copied to clipboard')).toBeTruthy();
+    await act(async () => {
+      vi.runAllTimers();
+    });
+    expect(screen.queryByText('Copied to clipboard')).toBeNull();
+    vi.useRealTimers();
   });
 });

--- a/apps/web/src/components/EvidenceDrawer.tsx
+++ b/apps/web/src/components/EvidenceDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 interface EvidenceDrawerProps {
   isOpen: boolean;
@@ -10,6 +10,19 @@ interface EvidenceDrawerProps {
 
 export default function EvidenceDrawer({ isOpen, onClose, children }: EvidenceDrawerProps) {
   const drawerRef = useRef<HTMLDivElement>(null);
+  const snippetRef = useRef<HTMLDivElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const text = snippetRef.current?.textContent ?? '';
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (e) {
+      console.error('Copy failed', e);
+    }
+  };
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -53,10 +66,19 @@ export default function EvidenceDrawer({ isOpen, onClose, children }: EvidenceDr
         tabIndex={-1}
         className="absolute right-0 top-0 h-full w-80 bg-white p-4 shadow-lg"
       >
-        {children}
-        <div className="mt-4 flex justify-end">
+        <div ref={snippetRef}>{children}</div>
+        <div className="mt-4 flex justify-end space-x-2">
+          <button onClick={handleCopy}>Copy</button>
           <button onClick={onClose}>Close</button>
         </div>
+        {copied && (
+          <div
+            role="status"
+            className="absolute bottom-4 right-4 rounded bg-gray-800 px-3 py-2 text-white"
+          >
+            Copied to clipboard
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed
- add copy-to-clipboard button with confirmation toast in EvidenceDrawer
- test copy and toast behavior in EvidenceDrawer

## Why (risk, user impact)
- improves usability by allowing quick copying of evidence snippets
- risk: low

## Tests & Evidence
- `pnpm -C apps/web lint`
- `pnpm -C apps/web typecheck`
- `pnpm -C apps/web test run`
- `pnpm -C apps/web build`

## Migration note
- none

## Rollback plan
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68b6adc5a61c832f87ba564cf0d28e01