### PR TITLE
[UI] track exported reports

### DIFF
--- a/apps/web/src/app/reports/page.test.tsx
+++ b/apps/web/src/app/reports/page.test.tsx
@@ -2,10 +2,21 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import ReportsPage from './page';
+import { mockReports } from '../../lib/mockReports';
 
 describe('ReportsPage', () => {
-  it('renders stub text', () => {
+  beforeEach(() => {
+    mockReports.length = 0;
+  });
+
+  it('renders stub text when no reports exist', () => {
     render(<ReportsPage />);
     expect(screen.getByText(/Report history will appear here/i)).toBeInTheDocument();
+  });
+
+  it('lists stored reports', () => {
+    mockReports.push({ id: 1, createdAt: '2024-01-01T00:00:00Z' });
+    render(<ReportsPage />);
+    expect(screen.getByText('Report 1')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/reports/page.tsx
+++ b/apps/web/src/app/reports/page.tsx
@@ -1,10 +1,20 @@
 import React from 'react';
+import { getReports } from '../../lib/mockReports';
 
 export default function ReportsPage() {
+  const reports = getReports();
   return (
     <main className="p-4">
       <h1 className="text-xl font-bold">Reports</h1>
-      <p>Report history will appear here.</p>
+      {reports.length === 0 ? (
+        <p>Report history will appear here.</p>
+      ) : (
+        <ul>
+          {reports.map((r) => (
+            <li key={r.id}>Report {r.id}</li>
+          ))}
+        </ul>
+      )}
     </main>
   );
 }

--- a/apps/web/src/components/ExportDialog.test.tsx
+++ b/apps/web/src/components/ExportDialog.test.tsx
@@ -2,17 +2,23 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import ExportDialog from './ExportDialog';
 import { vi } from 'vitest';
+import { mockReports } from '../lib/mockReports';
 
 const push = vi.fn();
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push }),
 }));
 
+beforeEach(() => {
+  mockReports.length = 0;
+});
+
 describe('ExportDialog', () => {
-  it('navigates to reports on confirm', () => {
+  it('saves report metadata and navigates to reports on confirm', () => {
     const onClose = vi.fn();
     const { getByText } = render(<ExportDialog isOpen onClose={onClose} />);
     fireEvent.click(getByText('Confirm'));
+    expect(mockReports).toHaveLength(1);
     expect(push).toHaveBeenCalledWith('/reports');
     expect(onClose).toHaveBeenCalled();
   });

--- a/apps/web/src/components/ExportDialog.tsx
+++ b/apps/web/src/components/ExportDialog.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
+import { addReport } from '../lib/mockReports';
 
 interface ExportDialogProps {
   isOpen: boolean;
@@ -47,6 +48,7 @@ export default function ExportDialog({ isOpen, onClose }: ExportDialogProps) {
   }, [isOpen, onClose]);
 
   const handleConfirm = () => {
+    addReport();
     router.push('/reports');
     onClose();
   };

--- a/apps/web/src/lib/mockReports.ts
+++ b/apps/web/src/lib/mockReports.ts
@@ -1,0 +1,17 @@
+export interface ReportMeta {
+  id: number;
+  createdAt: string;
+}
+
+export const mockReports: ReportMeta[] = [];
+
+export function addReport() {
+  mockReports.push({
+    id: mockReports.length + 1,
+    createdAt: new Date().toISOString(),
+  });
+}
+
+export function getReports() {
+  return mockReports;
+}


### PR DESCRIPTION
## What changed
- add in-memory mock report store
- record exports and redirect to reports page
- list stored reports on reports page
- add tests for export flow and report listing

## Why (risk, user impact)
- allows viewing previously exported reports during development
- low risk: feature uses in-memory mock data only

## Tests & Evidence
- `pnpm -C apps/web lint`
- `pnpm -C apps/web typecheck`
- `pnpm -C apps/web test run`
- `pnpm -C apps/web build`

## Migration note
none

## Rollback plan
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68b6adbd3b10832f8007e0b943174a5d