### PR TITLE
[UI] enable drag-and-drop contract upload

### DIFF
--- a/apps/web/src/app/upload/page.test.tsx
+++ b/apps/web/src/app/upload/page.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
+import UploadPage from './page';
+
+const pushMock = vi.fn();
+const originalFetch = global.fetch;
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+afterEach(() => {
+  pushMock.mockReset();
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('UploadPage', () => {
+  it('uploads a valid file and navigates', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ job_id: 'j1', analysis_id: 'a1', status: 'queued' }),
+    });
+    global.fetch = fetchMock as any;
+
+    const { container, getByText } = render(<UploadPage />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['data'], 'test.pdf', { type: 'application/pdf' });
+
+    await waitFor(() => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/analyses/a1'));
+    expect(getByText(/queued/i)).toBeInTheDocument();
+  });
+
+  it('shows error for unsupported file type', () => {
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as any;
+    const { container, getByRole } = render(<UploadPage />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['data'], 'test.txt', { type: 'text/plain' });
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(getByRole('alert')).toHaveTextContent(/only pdf or docx files are allowed/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('shows error for files over 10MB', () => {
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as any;
+    const { container, getByRole } = render(<UploadPage />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const bigData = new Uint8Array(11 * 1024 * 1024);
+    const file = new File([bigData], 'big.pdf', { type: 'application/pdf' });
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(getByRole('alert')).toHaveTextContent(/file must be 10mb or less/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/upload/page.tsx
+++ b/apps/web/src/app/upload/page.tsx
@@ -1,12 +1,78 @@
+"use client";
+
+import React, { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
 export default function UploadPage() {
+  const router = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<"idle" | "queued">("idle");
+
+  const handleFiles = async (files: FileList | null) => {
+    const file = files?.[0];
+    if (!file) return;
+
+    if (!/\.(pdf|docx)$/i.test(file.name)) {
+      setError("Only PDF or DOCX files are allowed");
+      return;
+    }
+    if (file.size > 10 * 1024 * 1024) {
+      setError("File must be 10MB or less");
+      return;
+    }
+
+    setError(null);
+    try {
+      const body = new FormData();
+      body.append("file", file);
+      const res = await fetch("/api/uploads", { method: "POST", body });
+      if (!res.ok) throw new Error("upload_failed");
+      const { analysis_id, status } = await res.json();
+      setStatus(status);
+      router.push(`/analyses/${analysis_id}`);
+    } catch {
+      setError("Upload failed");
+    }
+  };
+
+  const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
+  };
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleFiles(e.target.files);
+  };
+
   return (
     <div className="space-y-3">
       <h1 className="text-2xl font-semibold">Upload a contract</h1>
       <p className="text-sm text-muted-foreground">
-        Drop a file to create a new analysis. (Hook up to /api/uploads next.)
+        Drop a file to create a new analysis.
       </p>
-      {/* TODO: Dropzone + POST /api/uploads */}
-      <div className="rounded-2xl border p-8 text-center">Dropzone placeholder</div>
+      <div
+        className="rounded-2xl border p-8 text-center cursor-pointer"
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={onDrop}
+        onClick={() => inputRef.current?.click()}
+        role="button"
+        tabIndex={0}
+      >
+        {status === "queued" ? "Queued" : "Drop PDF or DOCX here"}
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".pdf,.docx"
+          className="hidden"
+          onChange={onChange}
+        />
+      </div>
+      {error && (
+        <p role="alert" className="text-sm text-red-600">
+          {error}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What changed
- replace placeholder with drag-and-drop uploader posting to `/api/uploads`
- validate PDF/DOCX files up to 10 MB and show queued status
- add tests for successful uploads and validation errors

## Why (risk, user impact)
Allows users to submit contracts directly from the browser while preventing unsupported or oversized files.

Story: `docs/stories/1.1-upload-job-orchestration.md`

## Tests & Evidence
- `pnpm -C apps/web install --frozen-lockfile`
- `pnpm -C apps/web lint`
- `pnpm -C apps/web test --run`
- `pnpm -C apps/web typecheck`
- `pnpm -C apps/web build`
- ⚠️ `pnpm -C apps/web exec playwright screenshot …` (missing Playwright browsers)

## Migration note
none

## Rollback plan
Revert the commits.

cc @codex

------
https://chatgpt.com/codex/tasks/task_e_68b6adbbd7d4832fa30c88ba89310676