### PR TITLE
fix(web): guard sparkline against empty timeseries

### DIFF
--- a/apps/web/src/app/admin/page.test.tsx
+++ b/apps/web/src/app/admin/page.test.tsx
@@ -6,6 +6,9 @@ import AdminPage from './page';
 describe('AdminPage', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+  });
+
+  it('fetches and displays metrics with sparklines', async () => {
     global.fetch = vi
       .fn()
       .mockResolvedValueOnce({
@@ -16,15 +19,46 @@ describe('AdminPage', () => {
       .mockResolvedValueOnce({
         json: async () => ({ users: [1, 2, 3, 4, 5] }),
       } as any);
-  });
-
-  it('fetches and displays metrics with sparklines', async () => {
     const { container } = render(<AdminPage />);
     await waitFor(() => screen.getByText('Users'));
     expect(screen.getByText('5')).toBeTruthy();
     expect(container.querySelectorAll('svg')).toHaveLength(1);
     expect(global.fetch).toHaveBeenCalledWith('/api/admin/metrics');
     expect(global.fetch).toHaveBeenCalledWith('/api/admin/metrics/timeseries');
+  });
+
+  it('renders fallback when timeseries has a single value', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        json: async () => [
+          { name: 'Users', value: 5, slug: 'users' },
+        ],
+      } as any)
+      .mockResolvedValueOnce({
+        json: async () => ({ users: [5] }),
+      } as any);
+    const { container } = render(<AdminPage />);
+    await waitFor(() => screen.getByText('Users'));
+    expect(container.querySelector('svg')).toBeNull();
+    expect(screen.getByLabelText('sparkline-fallback')).toBeTruthy();
+  });
+
+  it('renders fallback when timeseries values are all zero', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        json: async () => [
+          { name: 'Users', value: 5, slug: 'users' },
+        ],
+      } as any)
+      .mockResolvedValueOnce({
+        json: async () => ({ users: [0, 0, 0] }),
+      } as any);
+    const { container } = render(<AdminPage />);
+    await waitFor(() => screen.getByText('Users'));
+    expect(container.querySelector('svg')).toBeNull();
+    expect(screen.getByLabelText('sparkline-fallback')).toBeTruthy();
   });
 });
 

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -13,10 +13,23 @@ interface Timeseries {
 }
 
 const Sparkline = ({ data }: { data: number[] }) => {
-  if (!data || data.length === 0) return null;
+  if (!data || data.length < 2) {
+    return (
+      <div className="mt-2 text-gray-400" aria-label="sparkline-fallback">
+        –
+      </div>
+    );
+  }
   const width = 100;
   const height = 30;
   const max = Math.max(...data);
+  if (max <= 0) {
+    return (
+      <div className="mt-2 text-gray-400" aria-label="sparkline-fallback">
+        –
+      </div>
+    );
+  }
   const points = data
     .map((d, i) => {
       const x = (i / (data.length - 1)) * width;


### PR DESCRIPTION
## Summary
- guard sparkline against zero- or single-value series and render a fallback
- test sparkline fallback for single-point and all-zero series

## Testing
- `pnpm -C apps/web install --frozen-lockfile`
- `pnpm -C apps/web lint`
- `pnpm -C apps/web typecheck`
- `pnpm -C apps/web test -- --run`
- `pnpm -C apps/web build`


------
https://chatgpt.com/codex/tasks/task_e_68b6b1b727e8832fa38c5cab258e499f