### PR TITLE
[UI] add analyses list

### DIFF
--- a/apps/web/src/app/analyses/page.test.tsx
+++ b/apps/web/src/app/analyses/page.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import AnalysesPage from './page';
+
+describe('AnalysesPage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders analyses returned from API', async () => {
+    const analyses = [
+      { id: '1', name: 'Report A', status: 'pending' },
+      { id: '2', name: 'Report B', status: 'complete' },
+    ];
+
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => analyses,
+    } as any);
+
+    render(<AnalysesPage />);
+
+    expect(await screen.findByText('Report A')).toBeInTheDocument();
+    expect(screen.getByText('Report B')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no analyses returned', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    } as any);
+
+    render(<AnalysesPage />);
+
+    expect(
+      await screen.findByText(/No analyses yet\./i),
+    ).toBeInTheDocument();
+  });
+});
+

--- a/apps/web/src/app/analyses/page.tsx
+++ b/apps/web/src/app/analyses/page.tsx
@@ -1,17 +1,69 @@
-export default async function AnalysesPage() {
-  // TODO: fetch from API when ready
-  const items: { id: string; name: string; status: 'pending' | 'complete' }[] = [];
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+interface Analysis {
+  id: string;
+  name: string;
+  status: 'pending' | 'complete';
+}
+
+function statusStyle(status: Analysis['status']) {
+  switch (status) {
+    case 'complete':
+      return 'bg-green-100 text-green-800';
+    case 'pending':
+      return 'bg-yellow-100 text-yellow-800';
+    default:
+      return 'bg-gray-100 text-gray-800';
+  }
+}
+
+export default function AnalysesPage() {
+  const [items, setItems] = useState<Analysis[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/analyses');
+        if (!res.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const data = await res.json();
+        setItems(data);
+      } catch {
+        setError('Failed to load analyses.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, []);
+
   return (
     <div className="space-y-3">
       <h1 className="text-2xl font-semibold">Analyses</h1>
-      {items.length === 0 ? (
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading...</p>
+      ) : error ? (
+        <p className="text-sm text-red-500">{error}</p>
+      ) : items.length === 0 ? (
         <p className="text-sm text-muted-foreground">No analyses yet.</p>
       ) : (
         <ul className="divide-y rounded-2xl border">
           {items.map(a => (
             <li key={a.id} className="flex items-center justify-between p-4">
               <span>{a.name}</span>
-              <span className="text-xs uppercase">{a.status}</span>
+              <span
+                className={`px-2 py-1 text-xs font-semibold rounded-full ${statusStyle(
+                  a.status,
+                )}`}
+              >
+                {a.status.charAt(0).toUpperCase() + a.status.slice(1)}
+              </span>
             </li>
           ))}
         </ul>
@@ -19,3 +71,4 @@ export default async function AnalysesPage() {
     </div>
   );
 }
+


### PR DESCRIPTION
## What changed
- Fetch analyses from `/api/analyses` and render status chips with loading and error states
- Add tests for analyses list and empty state

## Why (risk, user impact)
- Surfaces available analyses to users
- risk: low – isolated UI feature

## Tests & Evidence
- `pnpm -C apps/web lint`
- `pnpm -C apps/web typecheck`
- `pnpm -C apps/web test --run`
- `pnpm -C apps/web build`

## Migration note
none

## Rollback plan
Revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68b6adbcbe38832f9ac620a0de6710d1