### PR TITLE
[Infra] add Windows helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ The orchestra agent has successfully implemented a **fully functional contract a
 Run the setup script to create a virtual environment and install dependencies:
 
 ```bash
-./scripts/setup.sh            # macOS/Linux
+./scripts/setup.sh                         # macOS/Linux
 # or
-pwsh -NoProfile -File ./setup.ps1  # Windows PowerShell
+pwsh -NoProfile -File tools/windows/setup.ps1  # Windows PowerShell
 ```
 
 Then start the API:
@@ -36,6 +36,14 @@ Then start the API:
 ```bash
 source .venv/bin/activate     # Windows: .\.venv\Scripts\Activate.ps1
 uvicorn blackletter_api.main:app --reload --app-dir apps/api
+```
+
+On Windows you can start the API and/or frontend with a helper script:
+
+```powershell
+pwsh -NoProfile -File tools/windows/dev.ps1      # run API and web
+pwsh -NoProfile -File tools/windows/dev.ps1 -Api # API only
+pwsh -NoProfile -File tools/windows/dev.ps1 -Web # web only
 ```
 
 > **Note**: The in-memory orchestrator uses thread locks for safety but

--- a/tools/windows/dev.ps1
+++ b/tools/windows/dev.ps1
@@ -1,0 +1,45 @@
+<#
+  Run API and/or Web dev servers on Windows.
+  Usage:
+    .\tools\windows\dev.ps1 -Api   # backend only
+    .\tools\windows\dev.ps1 -Web   # frontend only
+    .\tools\windows\dev.ps1        # both
+#>
+param(
+    [switch]$Api,
+    [switch]$Web
+)
+
+if (-not ($Api.IsPresent -or $Web.IsPresent)) {
+    $Api = $true
+    $Web = $true
+}
+
+$apiScript = {
+    Write-Host "Starting FastAPI API server..."
+    if (-not (Test-Path ".venv")) {
+        Write-Error "Virtual environment not found. Run tools\\windows\\setup.ps1 first."
+        return
+    }
+    . .\.venv\Scripts\Activate.ps1
+    $env:PYTHONPATH = ".;./apps/api"
+    uvicorn blackletter_api.main:app --reload --app-dir apps/api
+}
+
+$webScript = {
+    Write-Host "Starting Next.js web server..."
+    Push-Location "apps/web"
+    pnpm dev
+    Pop-Location
+}
+
+$jobs = @()
+if ($Api) { $jobs += Start-Job -ScriptBlock $apiScript }
+if ($Web) { $jobs += Start-Job -ScriptBlock $webScript }
+
+Write-Host "Development servers are starting. Press Ctrl+C to stop." -ForegroundColor Green
+while ($jobs.State -contains "Running") {
+    foreach ($job in $jobs) { Receive-Job $job }
+    Start-Sleep -Milliseconds 200
+}
+Remove-Job -Force -State Completed,Failed,Stopped

--- a/tools/windows/setup.ps1
+++ b/tools/windows/setup.ps1
@@ -1,0 +1,14 @@
+<#!
+  Windows setup wrapper.
+  Usage:
+    .\tools\windows\setup.ps1 [-RecreateVenv] [-SkipInstall]
+#>
+param(
+  [switch]$RecreateVenv,
+  [switch]$SkipInstall
+)
+
+$root = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
+$setup = Join-Path $root 'setup.ps1'
+
+& $setup @PSBoundParameters


### PR DESCRIPTION
## What changed
- add PowerShell wrappers for setup and dev server under `tools/windows`
- document Windows helper scripts in `README`

## Why (risk, user impact)
- streamlines Windows onboarding; low risk

## Tests & Evidence
- `pytest -q` *(fails: ImportError: cannot import name 'gemini_service')*

## Migration note (alembic)
- none

## Rollback plan
- revert commits

cc @codex

------
https://chatgpt.com/codex/tasks/task_e_68b6bbebcf08832fb28efcd59e252081