### PR TITLE
API add PDF report generation

### DIFF
--- a/apps/api/blackletter_api/migrations/versions/7b5c1ad9b3b8_add_file_path_to_reports.py
+++ b/apps/api/blackletter_api/migrations/versions/7b5c1ad9b3b8_add_file_path_to_reports.py
@@ -1,0 +1,17 @@
+"""add file_path to reports"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "7b5c1ad9b3b8"
+down_revision = "c4b32e6c5a41"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("reports", sa.Column("file_path", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("reports", "file_path")

--- a/apps/api/blackletter_api/models/entities.py
+++ b/apps/api/blackletter_api/models/entities.py
@@ -98,11 +98,15 @@ class Report(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     analysis_id = Column(String, nullable=False, index=True)
     filename = Column(String, nullable=False)
+    file_path = Column(String, nullable=True)
     created_at = Column(DateTime, nullable=False, server_default=func.now())
     options = Column(JSON, nullable=False)
 
     def __repr__(self):
-        return f"<Report(id={self.id}, analysis_id='{self.analysis_id}', filename='{self.filename}')>"
+        return (
+            f"<Report(id={self.id}, analysis_id='{self.analysis_id}', "
+            f"filename='{self.filename}', file_path='{self.file_path}')>"
+        )
 
 
 # Story 5.1 - Organization Settings model

--- a/apps/api/blackletter_api/models/schemas.py
+++ b/apps/api/blackletter_api/models/schemas.py
@@ -119,6 +119,7 @@ class ReportExport(BaseModel):
     id: str
     analysis_id: str
     filename: str
+    file_path: str | None = None
     created_at: str
     options: ExportOptions
 

--- a/apps/api/blackletter_api/routers/reports.py
+++ b/apps/api/blackletter_api/routers/reports.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import List
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from .. import database
-from ..models.entities import Report
-from ..models.schemas import ReportExport, ExportOptions
+from ..models.entities import Analysis, Report
+from ..models.schemas import ExportOptions, ReportExport
+from ..services.reports import generate_report_pdf
 
 router = APIRouter(tags=["reports"])
 
@@ -20,6 +23,7 @@ def list_reports(db: Session = Depends(database.get_db)) -> List[ReportExport]:
             id=str(r.id),
             analysis_id=r.analysis_id,
             filename=r.filename,
+            file_path=r.file_path,
             created_at=r.created_at.isoformat(),
             options=ExportOptions(**r.options),
         )
@@ -28,10 +32,27 @@ def list_reports(db: Session = Depends(database.get_db)) -> List[ReportExport]:
 
 
 @router.post("/reports/{analysis_id}", response_model=ReportExport, status_code=status.HTTP_201_CREATED)
-def create_report(analysis_id: str, opts: ExportOptions, db: Session = Depends(database.get_db)) -> ReportExport:
+def create_report(
+    analysis_id: str, opts: ExportOptions, db: Session = Depends(database.get_db)
+) -> ReportExport:
+    try:
+        analysis_uuid = UUID(analysis_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail="Invalid analysis id") from e
+
+    analysis = db.query(Analysis).filter(Analysis.id == analysis_uuid).first()
+    if not analysis:
+        raise HTTPException(status_code=404, detail="Analysis not found")
+
+    reports_dir = Path("reports")
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    output_path = reports_dir / f"{analysis_id.upper()}.pdf"
+    generate_report_pdf(analysis, output_path)
+
     report = Report(
         analysis_id=analysis_id,
-        filename=f"{analysis_id.upper()}.pdf",
+        filename=output_path.name,
+        file_path=str(output_path),
         options=opts.dict(),
     )
     db.add(report)
@@ -41,6 +62,7 @@ def create_report(analysis_id: str, opts: ExportOptions, db: Session = Depends(d
         id=str(report.id),
         analysis_id=report.analysis_id,
         filename=report.filename,
+        file_path=report.file_path,
         created_at=report.created_at.isoformat(),
         options=opts,
     )

--- a/apps/api/blackletter_api/services/reports.py
+++ b/apps/api/blackletter_api/services/reports.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Utilities for generating analysis reports as PDF files."""
+
+from pathlib import Path
+from typing import Any
+
+from jinja2 import Environment, select_autoescape
+from xhtml2pdf import pisa
+
+TEMPLATE = """\
+<html>
+  <body>
+    <h1>Report for {{ analysis.filename }}</h1>
+    <p>Analysis ID: {{ analysis.id }}</p>
+  </body>
+</html>
+"""
+
+env = Environment(autoescape=select_autoescape())
+
+
+def render_report_html(analysis: Any) -> str:
+    """Render an HTML report for an analysis object."""
+    template = env.from_string(TEMPLATE)
+    return template.render(analysis=analysis)
+
+
+def html_to_pdf(html: str, output_path: Path) -> Path:
+    """Convert HTML content into a PDF file at the given path."""
+    with open(output_path, "wb") as f:
+        result = pisa.CreatePDF(html, dest=f)
+    if result.err:
+        raise RuntimeError("PDF generation failed")
+    return output_path
+
+
+def generate_report_pdf(analysis: Any, output_path: Path) -> Path:
+    """Generate a PDF report for the given analysis and return the path."""
+    html = render_report_html(analysis)
+    return html_to_pdf(html, output_path)

--- a/apps/api/blackletter_api/tests/unit/test_reports_service.py
+++ b/apps/api/blackletter_api/tests/unit/test_reports_service.py
@@ -1,0 +1,20 @@
+from types import SimpleNamespace
+
+from blackletter_api.services.reports import (
+    generate_report_pdf,
+    render_report_html,
+)
+
+
+def test_render_report_html_includes_filename():
+    analysis = SimpleNamespace(id="123", filename="sample.txt")
+    html = render_report_html(analysis)
+    assert "sample.txt" in html
+
+
+def test_generate_report_pdf_creates_file(tmp_path):
+    analysis = SimpleNamespace(id="123", filename="sample.txt")
+    output = tmp_path / "report.pdf"
+    generate_report_pdf(analysis, output)
+    assert output.exists()
+    assert output.stat().st_size > 0

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -3,3 +3,6 @@ uvicorn
 celery
 redis
 fakeredis
+
+Jinja2
+xhtml2pdf


### PR DESCRIPTION
## What changed
- generate PDF report files from analyses via new Jinja2/xhtml2pdf service
- persist report file path on Report model and creation endpoint
- cover report HTML rendering and PDF creation with unit tests

## Why (risk, user impact)
- enables exporting analysis results as downloadable PDF artifacts
- low risk: scoped to new reports functionality

## Tests & Evidence
- `pip install -r apps/api/requirements.txt`
- `pytest apps/api/blackletter_api/tests/unit/test_reports_service.py apps/api/blackletter_api/tests/unit/test_reports_endpoints.py -q`
- `pytest -q apps/api` *(fails: errors in unrelated tests during collection)*
- `alembic upgrade head` *(fails: No config file 'alembic.ini' found)*

## Migration note (alembic)
- 7b5c1ad9b3b8

## Rollback plan
- revert commits and drop `file_path` column from `reports` table if necessary

------
https://chatgpt.com/codex/tasks/task_e_68b6bda9a434832f8a6a3d0bf80b0d74