### PR TITLE
[UI] add eslint/prettier workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+      - name: Check formatting
+        run: pnpm format
       - name: Lint
         run: pnpm lint
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start -p 3000",
-    "lint": "echo \"No lint\"",
+    "lint": "next lint",
+    "format": "prettier --check .",
+    "format:fix": "prettier --write .",
     "test": "vitest",
     "test:e2e": "playwright test",
     "e2e:install": "playwright install",
@@ -32,6 +34,7 @@
     "vitest": "^3.2.4",
     "@playwright/test": "^1.46.1",
     "eslint": "^8.57.0",
-    "eslint-config-next": "14.2.3"
+    "eslint-config-next": "14.2.3",
+    "prettier": "^3.6.2"
   }
 }

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       postcss:
         specifier: 8.4.31
         version: 8.4.31
+      prettier:
+        specifier: ^3.6.2
+        version: 3.6.2
       tailwindcss:
         specifier: 3.4.3
         version: 3.4.3
@@ -1934,6 +1937,11 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -4403,6 +4411,8 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier@3.6.2: {}
 
   pretty-format@27.5.1:
     dependencies:

--- a/apps/web/prettier.config.cjs
+++ b/apps/web/prettier.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  semi: true,
+  singleQuote: true,
+  trailingComma: 'all',
+  printWidth: 80,
+};


### PR DESCRIPTION
## What changed
- replace web lint placeholder with `next lint`
- add Prettier config and scripts
- run Prettier check in CI

## Why (risk, user impact)
- enables consistent linting and formatting for the Next.js app; low risk

## Tests & Evidence
- `pnpm --dir apps/web run lint`
- `pnpm --dir apps/web run test -- --run`
- `NEXT_DISABLE_ESLINT=1 pnpm --dir apps/web run build`
- `pnpm --dir apps/web run typecheck`

## Migration note
- none

## Rollback plan
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68b6bbe8cc8c832fbd26dbe8fad79d3b