### PR TITLE
[Infra] add docker-compose for api and web

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.9'
+services:
+  api:
+    image: python:3.11-slim
+    working_dir: /code
+    command: uvicorn blackletter_api.main:app --reload --host 0.0.0.0 --port 8000
+    env_file:
+      - .env
+    volumes:
+      - ./apps/api:/code
+      - api_data:/data
+    ports:
+      - "8000:8000"
+  web:
+    image: node:18-alpine
+    working_dir: /app
+    command: sh -c "pnpm install && pnpm dev"
+    env_file:
+      - .env
+    volumes:
+      - ./apps/web:/app
+      - web_node_modules:/app/node_modules
+    ports:
+      - "3000:3000"
+volumes:
+  api_data:
+  web_node_modules:


### PR DESCRIPTION
## What changed
- add dev `docker-compose.yml` to run API and Web with hot reload and persistent volumes

## Why (risk, user impact)
- simplifies local dev; risk low

## Tests & Evidence
- `pip install -r apps/api/requirements.txt`
- `pytest -q apps/api` *(fails: ImportError: cannot import name 'gemini_service')*
- `pnpm -C apps/web install --frozen-lockfile`
- `pnpm -C apps/web lint`
- `CI=1 pnpm -C apps/web test -- --run`
- `pnpm -C apps/web build`
- `pnpm -C apps/web typecheck`

## Migration note
- none

## Rollback plan
- revert this commit

@codex

------
https://chatgpt.com/codex/tasks/task_e_68b6bbed23b4832fbf6af5dffcfbfd28