### PR TITLE
[UI] export dialog posts reports

### DIFF
--- a/apps/web/src/components/ExportDialog.tsx
+++ b/apps/web/src/components/ExportDialog.tsx
@@ -1,17 +1,22 @@
 'use client';
 
-import React, { useEffect, useRef } from 'react';
-import { useRouter } from 'next/navigation';
-import { addReport } from '../lib/mockReports';
+import React, { useEffect, useRef, useState } from 'react';
 
 interface ExportDialogProps {
   isOpen: boolean;
   onClose: () => void;
+  analysisId: string;
 }
 
-export default function ExportDialog({ isOpen, onClose }: ExportDialogProps) {
-  const router = useRouter();
+export default function ExportDialog({
+  isOpen,
+  onClose,
+  analysisId,
+}: ExportDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
+  const [includeLogo, setIncludeLogo] = useState(true);
+  const [includeMeta, setIncludeMeta] = useState(true);
+  const [dateFormat, setDateFormat] = useState('mm/dd/yyyy');
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -47,10 +52,34 @@ export default function ExportDialog({ isOpen, onClose }: ExportDialogProps) {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [isOpen, onClose]);
 
-  const handleConfirm = () => {
-    addReport();
-    router.push('/reports');
-    onClose();
+  const handleConfirm = async () => {
+    try {
+      const res = await fetch(`/api/reports/${analysisId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          include_logo: includeLogo,
+          include_meta: includeMeta,
+          date_format: dateFormat,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error('Failed to export');
+      }
+
+      const { url } = await res.json();
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = '';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      onClose();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+    }
   };
 
   if (!isOpen) return null;
@@ -64,6 +93,36 @@ export default function ExportDialog({ isOpen, onClose }: ExportDialogProps) {
         className="relative z-10 rounded bg-white p-4 shadow-md"
       >
         <p className="mb-4">Export this analysis?</p>
+        <div className="mb-4 space-y-2">
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={includeLogo}
+              onChange={(e) => setIncludeLogo(e.target.checked)}
+            />
+            Include logo
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={includeMeta}
+              onChange={(e) => setIncludeMeta(e.target.checked)}
+            />
+            Include metadata
+          </label>
+          <label className="flex flex-col gap-1">
+            Date format
+            <select
+              value={dateFormat}
+              onChange={(e) => setDateFormat(e.target.value)}
+              className="border p-1"
+            >
+              <option value="mm/dd/yyyy">MM/DD/YYYY</option>
+              <option value="dd/mm/yyyy">DD/MM/YYYY</option>
+              <option value="yyyy-mm-dd">YYYY-MM-DD</option>
+            </select>
+          </label>
+        </div>
         <div className="flex justify-end gap-2">
           <button onClick={onClose}>Cancel</button>
           <button onClick={handleConfirm}>Confirm</button>


### PR DESCRIPTION
## What changed
- export dialog submits options to POST /reports/{analysis_id} and downloads the file
- collect logo, metadata, and date format options
- test option handling and API invocation

## Why (risk, user impact)
Enables configurable report exports via the backend API.

## Tests & Evidence
- `pnpm -C apps/web test --run`
- `pnpm -C apps/web build`
- `pnpm -C apps/web typecheck`

## Migration note
none

## Rollback plan
Revert this PR


------
https://chatgpt.com/codex/tasks/task_e_68b6bda88328832fb33af4ef102e128f