### PR TITLE
[UI] add analysis detail page with job status

### DIFF
--- a/apps/web/src/app/analyses/[id]/page.test.tsx
+++ b/apps/web/src/app/analyses/[id]/page.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { vi, Mock } from 'vitest';
+import AnalysisDetailPage from './page';
+import type { Finding } from '@/types';
+
+vi.mock('@/lib/useJobStatus');
+import useJobStatus from '@/lib/useJobStatus';
+
+describe('AnalysisDetailPage', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows progress while job is running', () => {
+    (useJobStatus as unknown as Mock).mockReturnValue({
+      status: 'queued',
+      findings: null,
+      error: null,
+    });
+
+    render(<AnalysisDetailPage params={{ id: '1' }} />);
+    expect(screen.getByText(/Status: Queued/i)).toBeInTheDocument();
+  });
+
+  it('renders findings when job complete', () => {
+    const findings: Finding[] = [
+      {
+        id: 'f1',
+        doc_id: 'd1',
+        rule_id: 'art28-3-a',
+        verdict: 'pass',
+        snippet: 'sample snippet',
+        location: { page: 1, start_char: 0, end_char: 6 },
+      },
+    ];
+
+    (useJobStatus as unknown as Mock).mockReturnValue({
+      status: 'done',
+      findings,
+      error: null,
+    });
+
+    render(<AnalysisDetailPage params={{ id: '1' }} />);
+    expect(screen.getByText('art28-3-a')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/analyses/[id]/page.tsx
+++ b/apps/web/src/app/analyses/[id]/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import React, { useState } from "react";
+import useJobStatus from "@/lib/useJobStatus";
+import FindingsTable from "@/components/FindingsTable";
+import FindingsDrawer from "@/components/FindingsDrawer";
+import type { Finding } from "@/types";
+
+interface PageProps {
+  params: { id: string };
+}
+
+export default function AnalysisDetailPage({ params }: PageProps) {
+  const { status, findings, error } = useJobStatus(params.id);
+  const [selected, setSelected] = useState<Finding | null>(null);
+
+  const handleSelect = (f: Finding) => setSelected(f);
+  const handleClose = () => setSelected(null);
+
+  if (error) {
+    return <p className="text-sm text-red-500">{error}</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      <h1 className="text-2xl font-semibold">Analysis {params.id}</h1>
+      {status !== "done" ? (
+        <p className="text-sm text-muted-foreground">
+          Status: {status.charAt(0).toUpperCase() + status.slice(1)}
+        </p>
+      ) : findings && findings.length > 0 ? (
+        <>
+          <FindingsTable findings={findings} onSelect={handleSelect} />
+          <FindingsDrawer
+            open={!!selected}
+            onClose={handleClose}
+            finding={
+              selected && {
+                rule: selected.rule_id,
+                evidence: selected.snippet,
+                verdict: selected.verdict,
+              }
+            }
+          />
+        </>
+      ) : (
+        <p className="text-sm text-muted-foreground">No findings.</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/analyses/page.tsx
+++ b/apps/web/src/app/analyses/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
 
 interface Analysis {
   id: string;
@@ -55,15 +56,20 @@ export default function AnalysesPage() {
       ) : (
         <ul className="divide-y rounded-2xl border">
           {items.map(a => (
-            <li key={a.id} className="flex items-center justify-between p-4">
-              <span>{a.name}</span>
-              <span
-                className={`px-2 py-1 text-xs font-semibold rounded-full ${statusStyle(
-                  a.status,
-                )}`}
+            <li key={a.id}>
+              <Link
+                href={`/analyses/${a.id}`}
+                className="flex items-center justify-between p-4 block"
               >
-                {a.status.charAt(0).toUpperCase() + a.status.slice(1)}
-              </span>
+                <span>{a.name}</span>
+                <span
+                  className={`px-2 py-1 text-xs font-semibold rounded-full ${statusStyle(
+                    a.status,
+                  )}`}
+                >
+                  {a.status.charAt(0).toUpperCase() + a.status.slice(1)}
+                </span>
+              </Link>
             </li>
           ))}
         </ul>

--- a/apps/web/src/components/FindingsTable.tsx
+++ b/apps/web/src/components/FindingsTable.tsx
@@ -7,11 +7,19 @@ import type { Finding } from '../types';
 
 interface FindingsTableProps {
   findings: Finding[];
+  onSelect?: (finding: Finding) => void;
 }
 
-export default function FindingsTable({ findings }: FindingsTableProps) {
+export default function FindingsTable({ findings, onSelect }: FindingsTableProps) {
   const [selected, setSelected] = useState<Finding | null>(null);
   const handleClose = () => setSelected(null);
+  const handleRowClick = (f: Finding) => {
+    if (onSelect) {
+      onSelect(f);
+    } else {
+      setSelected(f);
+    }
+  };
 
   return (
     <div className="space-y-4">
@@ -27,7 +35,7 @@ export default function FindingsTable({ findings }: FindingsTableProps) {
           {findings.map(f => (
             <tr
               key={f.id}
-              onClick={() => setSelected(f)}
+              onClick={() => handleRowClick(f)}
               className="cursor-pointer hover:bg-gray-50"
             >
               <td className="p-4">{f.rule_id}</td>
@@ -37,10 +45,12 @@ export default function FindingsTable({ findings }: FindingsTableProps) {
           ))}
         </tbody>
       </table>
-      <EvidenceDrawer isOpen={!!selected} onClose={handleClose}>
-        <p><span className="font-medium">Rule:</span> {selected?.rule_id}</p>
-        <p className="mt-2 whitespace-pre-wrap">{selected?.snippet}</p>
-      </EvidenceDrawer>
+      {!onSelect && (
+        <EvidenceDrawer isOpen={!!selected} onClose={handleClose}>
+          <p><span className="font-medium">Rule:</span> {selected?.rule_id}</p>
+          <p className="mt-2 whitespace-pre-wrap">{selected?.snippet}</p>
+        </EvidenceDrawer>
+      )}
     </div>
   );
 }

--- a/apps/web/src/lib/useJobStatus.ts
+++ b/apps/web/src/lib/useJobStatus.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import type { Finding } from '@/types';
+
+interface JobResponse {
+  status: 'queued' | 'running' | 'done' | 'error';
+  error?: string;
+}
+
+export default function useJobStatus(id: string) {
+  const [status, setStatus] = useState<JobResponse['status']>('queued');
+  const [findings, setFindings] = useState<Finding[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: NodeJS.Timeout;
+
+    const poll = async () => {
+      try {
+        const res = await fetch(`/api/jobs/${id}`);
+        if (!res.ok) throw new Error('status_failed');
+        const data: JobResponse = await res.json();
+        if (cancelled) return;
+        setStatus(data.status);
+        if (data.status === 'done') {
+          const fRes = await fetch(`/api/analyses/${id}`);
+          if (!fRes.ok) throw new Error('findings_failed');
+          const fData = await fRes.json();
+          if (cancelled) return;
+          setFindings(fData.findings || fData);
+        } else if (data.status === 'queued' || data.status === 'running') {
+          timer = setTimeout(poll, 1000);
+        }
+      } catch {
+        if (!cancelled) setError('Failed to load job status.');
+      }
+    };
+
+    poll();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [id]);
+
+  return { status, findings, error };
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## What changed
- link analyses list items to detail view
- add job status hook and analysis detail page rendering findings
- tests for progress and final findings

## Why (risk, user impact)
- enables users to monitor analysis progress and review findings once complete; risk low

## Tests & Evidence
- `pnpm -C apps/web lint`
- `pnpm -C apps/web test --run`
- `pnpm -C apps/web build`
- `pnpm -C apps/web typecheck`

## Migration note (alembic)
- none

## Rollback plan
- revert this PR

@codex

------
https://chatgpt.com/codex/tasks/task_e_68b6be0ad64c832f9283f53af3f6662b