### PR TITLE
[UI] wire upload to findings flow

### DIFF
--- a/apps/api/blackletter_api/main.py
+++ b/apps/api/blackletter_api/main.py
@@ -18,7 +18,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from .database import engine, Base
 from .models import entities
-from .routers import rules, analyses
+from .routers import rules, analyses, findings
 from .routers import contracts, jobs, reports
 from .routers import risk_analysis, admin
 from .routers import orchestration, gemini
@@ -186,6 +186,7 @@ async def get_live_analysis_status(analysis_id: str):
     }
 app.include_router(rules.router, prefix="/api")
 app.include_router(analyses.router, prefix="/api")
+app.include_router(findings.router, prefix="/api")
 app.include_router(contracts.router, prefix="/api")
 app.include_router(jobs.router, prefix="/api")
 app.include_router(reports.router, prefix="/api")

--- a/apps/api/blackletter_api/routers/findings.py
+++ b/apps/api/blackletter_api/routers/findings.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, HTTPException, Query
+
+from ..models.schemas import Finding
+from ..services.tasks import get_job
+from ..services import storage
+
+router = APIRouter(tags=["findings"])
+
+
+@router.get("/findings", response_model=List[Finding])
+def get_findings(job_id: str = Query(...)) -> List[Finding]:
+    job = get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="not_found")
+    data = storage.get_analysis_findings(job.analysis_id)
+    return [Finding(**f) for f in data]

--- a/apps/api/blackletter_api/tests/integration/test_findings_endpoint.py
+++ b/apps/api/blackletter_api/tests/integration/test_findings_endpoint.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from blackletter_api.main import app
+from blackletter_api.services.rulepack_loader import Rulepack, Detector, Lexicon
+
+
+client = TestClient(app)
+
+
+def test_get_findings_by_job(monkeypatch) -> None:
+    monkeypatch.setenv("JOB_SYNC", "1")
+
+    mock_extraction_data = {
+        "text_path": "extracted.txt",
+        "page_map": [{"page": 1, "start": 0, "end": 100}],
+        "sentences": [
+            {"page": 1, "start": 0, "end": 20, "text": "This document may contain sensitive information."},
+            {"page": 1, "start": 21, "end": 45, "text": "You should review it carefully."},
+            {"page": 1, "start": 46, "end": 70, "text": "It might be important."},
+        ],
+    }
+
+    def mock_run_extraction(analysis_id: str, source_file: Path, out_dir: Path):
+        extraction_path = out_dir / "extraction.json"
+        with extraction_path.open("w", encoding="utf-8") as f:
+            json.dump(mock_extraction_data, f)
+        return extraction_path
+
+    monkeypatch.setattr("blackletter_api.services.tasks.run_extraction", mock_run_extraction)
+
+    mock_rulepack = Rulepack(
+        name="test-rulepack",
+        version="v1",
+        detectors=[
+            Detector(
+                id="D001",
+                type="lexicon",
+                lexicon="weak-language",
+                description="Detects weak language.",
+            )
+        ],
+        lexicons={
+            "weak-language": Lexicon(
+                name="weak-language",
+                terms=["may", "might", "could", "should"],
+            )
+        },
+    )
+
+    monkeypatch.setattr(
+        "blackletter_api.services.detector_runner.load_rulepack", lambda: mock_rulepack
+    )
+
+    files = {"file": ("doc.pdf", BytesIO(b"dummy"), "application/pdf")}
+    resp = client.post("/api/contracts", files=files)
+    job_id = resp.json()["id"]
+
+    fr = client.get("/api/findings", params={"job_id": job_id})
+    assert fr.status_code == 200
+    findings = fr.json()
+    assert isinstance(findings, list)
+    assert len(findings) == 3

--- a/apps/web/src/app/analyses/[jobId]/page.tsx
+++ b/apps/web/src/app/analyses/[jobId]/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type Finding = {
+  rule_id: string;
+  verdict: string;
+  snippet: string;
+};
+
+export default function AnalysisFindingsPage({ params }: { params: { jobId: string } }) {
+  const [findings, setFindings] = useState<Finding[]>([]);
+
+  useEffect(() => {
+    fetch(`/api/findings?job_id=${params.jobId}`)
+      .then((res) => res.json())
+      .then((data) => setFindings(data))
+      .catch(() => setFindings([]));
+  }, [params.jobId]);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Findings</h1>
+      <table className="min-w-full text-left border">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1">Rule</th>
+            <th className="border px-2 py-1">Verdict</th>
+            <th className="border px-2 py-1">Snippet</th>
+          </tr>
+        </thead>
+        <tbody>
+          {findings.map((f, idx) => (
+            <tr key={idx}>
+              <td className="border px-2 py-1">{f.rule_id}</td>
+              <td className="border px-2 py-1">{f.verdict}</td>
+              <td className="border px-2 py-1">{f.snippet}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed
- add `/api/findings` endpoint to fetch findings by job id
- hook upload page to contract/job APIs and render findings table

## Why (risk, user impact)
- enables end-to-end contract analysis flow from upload through findings
- low risk: new endpoint reads stored artifacts without modifying data

## Tests & Evidence
- `pytest -q apps/api` *(fails: sqlalchemy invalid request, etc.)*
- `pnpm -C apps/web test -- --run` *(fails: TypeError: Failed to parse URL from /api/contracts)*
- `pnpm -C apps/web typecheck`
- `pnpm -C apps/web build`

## Migration note
none

## Rollback plan
Revert the commits.

@codex

------
https://chatgpt.com/codex/tasks/task_e_68b6772ffbf8832fb9bfc138432376c7