### PR TITLE
[Docs] use pnpm for frontend dev commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ uvicorn blackletter_api.main:app --reload --app-dir apps/api
 ### Frontend (Ready for Development)
 ```bash
 cd apps/web
-npm install
-npm run dev
+pnpm install
+pnpm dev
 ```
+
+> **Note**: These commands assume a `pnpm-workspace.yaml` exists at the repository root to enable pnpm workspace features.
 
 ### Demo Mode
 

--- a/docs/dev/always-on-dev-guide.md
+++ b/docs/dev/always-on-dev-guide.md
@@ -4,8 +4,8 @@ Use this as your quick‑start and navigation map. It outlines agent flows, the 
 
 ## Quick Commands
 
-- Web dev: `cd apps/web && npm install && npm run dev` (open http://localhost:3000)
-- Web lint/tests: `npm run lint` • `npm run test` • `npm run coverage`
+- Web dev: `cd apps/web && pnpm install && pnpm dev` (open http://localhost:3000)
+- Web lint/tests: `pnpm lint` • `pnpm test` • `pnpm coverage`
 - Demo mode: copy `apps/web/.env.example` to `.env.local` and keep `NEXT_PUBLIC_USE_MOCKS=1`
 - API dev: `cd apps/api && uvicorn blackletter_api.main:app --reload`
 - API tests: `pytest apps/api/blackletter_api/tests -q`

--- a/docs/dev/guides/develop-story-flow.md
+++ b/docs/dev/guides/develop-story-flow.md
@@ -21,13 +21,13 @@ This guide operationalizes the BMAD develop-story process so Devs can implement 
 - Mark checkboxes, update File List and Change Log, set status when done
 
 ## Commands (Windows PowerShell)
-- Web: `cd apps/web; npm install; npm run lint; npm run test; npm run dev`
+- Web: `cd apps/web; pnpm install; pnpm lint; pnpm test; pnpm dev`
 - API: `cd apps/api; pip install -r requirements.txt; uvicorn blackletter_api.main:app --reload`
 - API tests: `pytest apps/api/blackletter_api/tests -q`
 
 ## Web Testing
 - Unit/integration (RTL + Jest): `apps/web/test/**/*.test.tsx`
-- Coverage: `npm run coverage`
+- Coverage: `pnpm coverage`
 - Accessibility: test roles, labels, ESC behavior, focus
 
 ## API Testing


### PR DESCRIPTION
## What changed
- replace npm install/dev instructions with pnpm equivalents
- note `pnpm-workspace.yaml` requirement for pnpm workspaces

## Why (risk, user impact)
Aligns documentation with pnpm usage to avoid inconsistent dependency installs. Risk: low.

## Tests & Evidence
- `pnpm -C apps/web install --frozen-lockfile`
- `pnpm -C apps/web lint`
- `pnpm -C apps/web test --run`
- `pnpm -C apps/web build`
- `pnpm -C apps/web typecheck`

## Migration note (alembic)
none

## Rollback plan
Revert commit.

@codex

------
https://chatgpt.com/codex/tasks/task_e_68b6c3682a4c832f94f5f8056dc56446