### PR TITLE
[API] add organization switching endpoints

### DIFF
--- a/apps/api/blackletter_api/main.py
+++ b/apps/api/blackletter_api/main.py
@@ -29,7 +29,7 @@ from .routers import contracts, jobs, reports
 from .routers import risk_analysis, admin
 from .routers import orchestration, gemini
 from .routers import document_qa
-from .routers import auth, devtools, settings
+from .routers import auth, devtools, settings, organizations
 
 # Create the database tables
 entities.Base.metadata.create_all(bind=engine)
@@ -219,3 +219,4 @@ app.include_router(document_qa.router, prefix="/api")
 app.include_router(auth.router, prefix="/api")
 app.include_router(devtools.router, prefix="/api/dev")
 app.include_router(settings.router)
+app.include_router(organizations.router, prefix="/api")

--- a/apps/api/blackletter_api/models/auth.py
+++ b/apps/api/blackletter_api/models/auth.py
@@ -1,10 +1,9 @@
 import uuid
-from sqlalchemy import (
-    Boolean, Column, String, DateTime, ForeignKey, Text, JSON
-)
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
+
 from ..database import Base
 
 
@@ -19,27 +18,6 @@ class User(Base):
     last_login_at = Column(DateTime)
 
     memberships = relationship("OrgMember", back_populates="user")
-
-
-class Org(Base):
-    __tablename__ = "orgs"
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    name = Column(String(255), nullable=False)
-    slug = Column(String(100), unique=True, index=True)
-    created_at = Column(DateTime, server_default=func.now())
-
-    members = relationship("OrgMember", back_populates="org")
-
-
-class OrgMember(Base):
-    __tablename__ = "org_members"
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    org_id = Column(UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False)
-    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
-    role = Column(String(50), nullable=False, default='reviewer')
-
-    org = relationship("Org", back_populates="members")
-    user = relationship("User", back_populates="memberships")
 
 
 class Session(Base):

--- a/apps/api/blackletter_api/models/organization.py
+++ b/apps/api/blackletter_api/models/organization.py
@@ -1,0 +1,29 @@
+import uuid
+from sqlalchemy import Column, DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from ..database import Base
+
+
+class Org(Base):
+    __tablename__ = "orgs"
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String(255), nullable=False)
+    slug = Column(String(100), unique=True, index=True)
+    created_at = Column(DateTime, server_default=func.now())
+
+    members = relationship("OrgMember", back_populates="org")
+
+
+class OrgMember(Base):
+    __tablename__ = "org_members"
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    role = Column(String(50), nullable=False, default="reviewer")
+
+    org = relationship("Org", back_populates="members")
+    user = relationship("User", back_populates="memberships")
+

--- a/apps/api/blackletter_api/routers/auth.py
+++ b/apps/api/blackletter_api/routers/auth.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, EmailStr
 
 from .. import database
 from ..models import auth as auth_models
+from ..models.organization import OrgMember
 from ..services.auth_service import auth_service
 
 router = APIRouter(
@@ -64,7 +65,7 @@ async def login(response: Response, user_credentials: UserLogin, db: Session = D
     expires_at = auth_service.get_session_expiry()
 
     # Find first org membership
-    first_membership = db.query(auth_models.OrgMember).filter(auth_models.OrgMember.user_id == user.id).first()
+    first_membership = db.query(OrgMember).filter(OrgMember.user_id == user.id).first()
     if not first_membership:
         raise HTTPException(status_code=403, detail="User has no organization membership.")
 
@@ -85,7 +86,7 @@ async def login(response: Response, user_credentials: UserLogin, db: Session = D
         samesite="lax",
         expires=expires_at,
     )
-    return {"message": "Login successful"}
+    return {"message": "Login successful", "organization_id": str(new_session.org_id)}
 
 
 @router.post("/logout")

--- a/apps/api/blackletter_api/routers/organizations.py
+++ b/apps/api/blackletter_api/routers/organizations.py
@@ -1,0 +1,61 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+
+from .. import database
+from ..models.organization import Org, OrgMember
+from ..models.auth import Session as SessionModel
+from ..services.session import SessionClaims, require_session
+
+
+router = APIRouter(prefix="/v1/organizations", tags=["Organizations"])
+
+
+class OrgOut(BaseModel):
+    id: str
+    name: str
+    slug: str | None = None
+
+
+class SwitchOrgRequest(BaseModel):
+    org_id: str
+
+
+@router.get("/", response_model=list[OrgOut])
+def list_user_organizations(
+    claims: SessionClaims = Depends(require_session),
+    db: Session = Depends(database.get_db),
+) -> list[OrgOut]:
+    orgs = (
+        db.query(Org)
+        .join(OrgMember, Org.id == OrgMember.org_id)
+        .filter(OrgMember.user_id == claims.user_id)
+        .all()
+    )
+    return [OrgOut(id=str(o.id), name=o.name, slug=o.slug) for o in orgs]
+
+
+@router.post("/switch")
+def switch_organization(
+    request: SwitchOrgRequest,
+    claims: SessionClaims = Depends(require_session),
+    db: Session = Depends(database.get_db),
+) -> dict[str, str]:
+    membership = (
+        db.query(OrgMember)
+        .filter(OrgMember.user_id == claims.user_id, OrgMember.org_id == request.org_id)
+        .first()
+    )
+    if not membership:
+        raise HTTPException(status_code=403, detail="User not a member of organization")
+
+    session = (
+        db.query(SessionModel)
+        .filter(SessionModel.session_token == claims.session_token)
+        .first()
+    )
+    session.org_id = request.org_id
+    db.commit()
+
+    return {"organization_id": request.org_id}
+

--- a/apps/api/blackletter_api/services/session.py
+++ b/apps/api/blackletter_api/services/session.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from fastapi import Cookie, Depends, HTTPException
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+
+from .. import database
+from ..models.auth import Session as SessionModel
+
+
+class SessionClaims(BaseModel):
+    session_token: str
+    user_id: str
+    organization_id: str
+
+
+def require_session(
+    bl_sess: str | None = Cookie(None),
+    db: Session = Depends(database.get_db),
+) -> SessionClaims:
+    if bl_sess is None:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    session = (
+        db.query(SessionModel)
+        .filter(SessionModel.session_token == bl_sess)
+        .first()
+    )
+    if not session or session.expires_at < datetime.utcnow():
+        raise HTTPException(status_code=401, detail="Invalid session")
+
+    return SessionClaims(
+        session_token=bl_sess,
+        user_id=str(session.user_id),
+        organization_id=str(session.org_id),
+    )

--- a/apps/api/blackletter_api/tests/conftest.py
+++ b/apps/api/blackletter_api/tests/conftest.py
@@ -21,7 +21,7 @@ def auth_pepper_env(monkeypatch) -> None:
 from sqlalchemy import create_engine
 
 from blackletter_api import database
-from blackletter_api.models import entities, auth as auth_models  # noqa: F401
+from blackletter_api.models import entities, auth as auth_models, organization as organization_models  # noqa: F401
 
 # Rebind engine to a known absolute path and ensure tables exist
 db_path = Path(__file__).resolve().parents[3] / "test.db"

--- a/apps/api/blackletter_api/tests/integration/test_organization_switch.py
+++ b/apps/api/blackletter_api/tests/integration/test_organization_switch.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timedelta
+from fastapi.testclient import TestClient
+
+from apps.api.blackletter_api.main import app
+from apps.api.blackletter_api import database
+from apps.api.blackletter_api.models.auth import User, Session
+from apps.api.blackletter_api.models.organization import Org, OrgMember
+
+client = TestClient(app)
+
+
+def setup_module(_: object) -> None:
+    db = database.SessionLocal()
+    try:
+        db.query(Session).delete()
+        db.query(OrgMember).delete()
+        db.query(Org).delete()
+        db.query(User).delete()
+        db.commit()
+
+        user = User(email="user@example.com", password_hash="hash")
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+        org1 = Org(name="Org 1", slug="org1")
+        org2 = Org(name="Org 2", slug="org2")
+        db.add_all([org1, org2])
+        db.commit()
+        db.refresh(org1)
+        db.refresh(org2)
+
+        db.add_all([
+            OrgMember(org_id=org1.id, user_id=user.id),
+            OrgMember(org_id=org2.id, user_id=user.id),
+        ])
+        session = Session(
+            session_token="token123",
+            user_id=user.id,
+            org_id=org1.id,
+            expires_at=datetime.utcnow() + timedelta(days=1),
+        )
+        db.add(session)
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_list_and_switch_organization() -> None:
+    cookies = {"bl_sess": "token123"}
+
+    resp = client.get("/api/v1/organizations", cookies=cookies)
+    assert resp.status_code == 200
+    orgs = resp.json()
+    assert len(orgs) == 2
+
+    new_org_id = orgs[1]["id"]
+    resp = client.post(
+        "/api/v1/organizations/switch",
+        json={"org_id": new_org_id},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["organization_id"] == new_org_id
+
+    db = database.SessionLocal()
+    try:
+        session = db.query(Session).filter_by(session_token="token123").first()
+        assert str(session.org_id) == new_org_id
+    finally:
+        db.close()
+


### PR DESCRIPTION
## What changed
- define `Org` and `OrgMember` models and expose org claim in login
- add session helper and organizations router for listing and switching orgs
- cover organization switching with integration test

## Why (risk, user impact)
- enables multi-organization workflows by letting users change active organization
- low risk: new tables and endpoints are isolated from existing flows

## Tests & Evidence
- `pip install -r apps/api/requirements.txt`
- `pytest -q apps/api` *(fails: cannot import name 'gemini_service')*
- `pytest -q apps/api/blackletter_api/tests/integration/test_organization_switch.py` *(fails: cannot import name 'gemini_service')*

## Migration note
- none

## Rollback plan
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68b6c35584ac832fbe64fb7bb94a7977