### PR TITLE
[UI] add reusable upload dropzone component

### DIFF
--- a/apps/web/src/app/upload/page.test.tsx
+++ b/apps/web/src/app/upload/page.test.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom/vitest';
-import { vi } from 'vitest';
-import UploadPage from './page';
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+import UploadPage from "./page";
 
 const pushMock = vi.fn();
 const originalFetch = global.fetch;
 
-vi.mock('next/navigation', () => ({
+vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: pushMock }),
 }));
 
@@ -17,50 +17,23 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('UploadPage', () => {
-  it('uploads a valid file and navigates', async () => {
+describe("UploadPage", () => {
+  it("uploads a valid file and navigates", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ job_id: 'j1', analysis_id: 'a1', status: 'queued' }),
+      json: async () => ({ analysis_id: "a1" }),
     });
     global.fetch = fetchMock as any;
 
     const { container, getByText } = render(<UploadPage />);
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;
-    const file = new File(['data'], 'test.pdf', { type: 'application/pdf' });
+    const file = new File(["data"], "test.pdf", { type: "application/pdf" });
 
     await waitFor(() => {
       fireEvent.change(input, { target: { files: [file] } });
     });
 
-    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/analyses/a1'));
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/analyses/a1"));
     expect(getByText(/queued/i)).toBeInTheDocument();
-  });
-
-  it('shows error for unsupported file type', () => {
-    const fetchMock = vi.fn();
-    global.fetch = fetchMock as any;
-    const { container, getByRole } = render(<UploadPage />);
-    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
-    const file = new File(['data'], 'test.txt', { type: 'text/plain' });
-
-    fireEvent.change(input, { target: { files: [file] } });
-
-    expect(getByRole('alert')).toHaveTextContent(/only pdf or docx files are allowed/i);
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it('shows error for files over 10MB', () => {
-    const fetchMock = vi.fn();
-    global.fetch = fetchMock as any;
-    const { container, getByRole } = render(<UploadPage />);
-    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
-    const bigData = new Uint8Array(11 * 1024 * 1024);
-    const file = new File([bigData], 'big.pdf', { type: 'application/pdf' });
-
-    fireEvent.change(input, { target: { files: [file] } });
-
-    expect(getByRole('alert')).toHaveTextContent(/file must be 10mb or less/i);
-    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/upload-dropzone.test.tsx
+++ b/apps/web/src/components/upload-dropzone.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+import { UploadDropzone } from "./upload-dropzone";
+
+describe("UploadDropzone", () => {
+  it("calls onUpload for valid file", async () => {
+    const onUpload = vi.fn().mockResolvedValue(undefined);
+    const { container } = render(<UploadDropzone onUpload={onUpload} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["data"], "test.pdf", { type: "application/pdf" });
+
+    await waitFor(() => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+
+    await waitFor(() => expect(onUpload).toHaveBeenCalledWith(file));
+  });
+
+  it("shows error for unsupported file type", () => {
+    const onUpload = vi.fn();
+    const { container, getByRole } = render(<UploadDropzone onUpload={onUpload} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["data"], "test.txt", { type: "text/plain" });
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(getByRole("alert")).toHaveTextContent(/only pdf or docx files are allowed/i);
+    expect(onUpload).not.toHaveBeenCalled();
+  });
+
+  it("shows error for files over 10MB", () => {
+    const onUpload = vi.fn();
+    const { container, getByRole } = render(<UploadDropzone onUpload={onUpload} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const bigData = new Uint8Array(11 * 1024 * 1024);
+    const file = new File([bigData], "big.pdf", { type: "application/pdf" });
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(getByRole("alert")).toHaveTextContent(/file must be 10mb or less/i);
+    expect(onUpload).not.toHaveBeenCalled();
+  });
+
+  it("handles drag and drop", async () => {
+    const onUpload = vi.fn().mockResolvedValue(undefined);
+    const { getByTestId } = render(<UploadDropzone onUpload={onUpload} />);
+    const dropzone = getByTestId("dropzone");
+    const file = new File(["data"], "test.pdf", { type: "application/pdf" });
+
+    fireEvent.dragOver(dropzone, { dataTransfer: { files: [file] } });
+    fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
+
+    await waitFor(() => expect(onUpload).toHaveBeenCalledWith(file));
+  });
+});

--- a/apps/web/src/components/upload-dropzone.tsx
+++ b/apps/web/src/components/upload-dropzone.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import React, { useRef, useState } from "react";
+
+interface UploadDropzoneProps {
+  onUpload: (file: File) => Promise<void> | void;
+  disabled?: boolean;
+  messages?: {
+    idle?: string;
+    queued?: string;
+    invalidType?: string;
+    tooLarge?: string;
+    uploadFailed?: string;
+  };
+}
+
+export function UploadDropzone({
+  onUpload,
+  disabled = false,
+  messages = {},
+}: UploadDropzoneProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const handleFiles = async (files: FileList | null) => {
+    const file = files?.[0];
+    if (!file) return;
+
+    if (!/\.(pdf|docx)$/i.test(file.name)) {
+      setError(messages.invalidType ?? "Only PDF or DOCX files are allowed");
+      return;
+    }
+    if (file.size > 10 * 1024 * 1024) {
+      setError(messages.tooLarge ?? "File must be 10MB or less");
+      return;
+    }
+
+    setError(null);
+    try {
+      await onUpload(file);
+    } catch {
+      setError(messages.uploadFailed ?? "Upload failed");
+    }
+  };
+
+  const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+    handleFiles(e.dataTransfer.files);
+  };
+
+  const onDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    if (!isDragging) setIsDragging(true);
+  };
+
+  const onDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+  };
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleFiles(e.target.files);
+  };
+
+  const idleText = messages.idle ?? "Drop PDF or DOCX here";
+  const queuedText = messages.queued ?? "Queued";
+
+  return (
+    <div className="space-y-3">
+      <div
+        className={`rounded-2xl border p-8 text-center cursor-pointer${
+          isDragging ? " bg-muted" : ""
+        }${disabled ? " opacity-50 cursor-not-allowed" : ""}`}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+        onClick={() => !disabled && inputRef.current?.click()}
+        role="button"
+        tabIndex={0}
+        data-testid="dropzone"
+      >
+        {disabled ? queuedText : idleText}
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".pdf,.docx"
+          className="hidden"
+          onChange={onChange}
+          disabled={disabled}
+        />
+      </div>
+      {error && (
+        <p role="alert" className="text-sm text-red-600">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default UploadDropzone;


### PR DESCRIPTION
## What changed
- Introduced `UploadDropzone` component with drag/drop handling, file validation, and error display.
- Updated upload page to use the new component and delegate upload logic.
- Added tests for valid uploads, invalid type, oversize file, and drag-drop interactions.

## Why (risk, user impact)
- Centralizes file upload logic for reuse and maintainability.
- Risk: low

## Tests & Evidence
- `pnpm -C apps/web lint`
- `pnpm -C apps/web test run`
- `pnpm -C apps/web build`
- `pnpm -C apps/web typecheck`

## Migration note (alembic)
- none

## Rollback plan
- Revert this PR.


------
https://chatgpt.com/codex/tasks/task_e_68b6be0ddee4832facd6817bc3aab201