### PR TITLE
[Docs] add compliance modes story

### DIFF
--- a/docs/stories/6.1-compliance-modes.md
+++ b/docs/stories/6.1-compliance-modes.md
@@ -1,0 +1,45 @@
+id: 6.1
+epic: 6
+title: Compliance Modes
+status: draft
+story: |
+  As an **admin**, I want to configure compliance modes—LLM usage, OCR opt‑in, and evidence window size—so that system behavior aligns with organizational policy.
+acceptance_criteria:
+  - Admin can enable/disable all LLM features via a kill‑switch (includes snippet‑only mode).
+  - OCR processing is disabled by default and requires explicit opt‑in.
+  - Evidence window size is configurable per org (default ±2 sentences; max ±5).
+  - Changes persist per organization and take effect on subsequent analysis jobs.
+notes:
+  - Settings live under org configuration and must persist across sessions.
+  - Kill‑switch disables all LLM calls and surfaces a notice in UI.
+  - Snippet‑only mode stores only minimal excerpts; full documents remain ephemeral.
+  - UI should clearly show when OCR or LLM features are disabled.
+tasks_subtasks: |
+  - [ ] **Backend API**
+    - [ ] Extend `OrgSettings` model with `llm_enabled`, `ocr_enabled`, `evidence_window_size`.
+    - [ ] Add `GET/PUT /api/org/settings` endpoints for retrieve/update.
+    - [ ] Enforce flags in upload/analysis pipeline and detector services.
+  - [ ] **Frontend UI**
+    - [ ] Add admin settings section with toggles for LLM kill‑switch and OCR, plus numeric input for evidence window size.
+    - [ ] Display warnings when LLM disabled or OCR off.
+  - [ ] **Testing**
+    - [ ] Unit tests for settings API.
+    - [ ] Integration test ensuring kill‑switch bypasses LLM calls.
+    - [ ] UI tests verifying toggle persistence and evidence window updates.
+dev_agent_record:
+  proposed_tasks:
+    - backend: add settings model & API; integrate flags in services.
+    - frontend: settings UI with toggles and evidence window input.
+    - tests: API, service enforcement, UI toggles.
+  open_decisions:
+    - Bound evidence window size (e.g., 1‑5 sentences)?
+    - Default state for `llm_enabled` and `ocr_enabled` (off vs. on).
+dev_spec: |
+  - Model: `apps/api/blackletter_api/models/org_settings.py` adds fields above.
+  - API: `GET /api/org/settings` returns current config; `PUT` updates.
+  - Enforcement: processing services skip LLM/OCR when flags disabled; evidence window uses configured size.
+qa_tests: |
+  - API update persists and reflects on reload.
+  - Kill‑switch: uploading doc triggers no LLM calls when disabled.
+  - OCR: scanned PDFs rejected unless OCR enabled.
+  - Evidence window: detectors honor updated window size in responses.


### PR DESCRIPTION
## What changed
- document compliance modes story covering LLM kill-switch, OCR opt-in, and evidence window configuration

## Why (risk, user impact)
- captures requirements for future compliance features; low risk as docs-only

## Tests & Evidence
- `pytest -q` *(fails: ImportError: cannot import name 'gemini_service')*

## Migration note
- none

## Rollback plan
- revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68b6be4484a8832fb878913d30be1916