### PR TITLE
[UI] handle missing verdicts in findings table

### DIFF
--- a/apps/web/src/components/FindingsTable.test.tsx
+++ b/apps/web/src/components/FindingsTable.test.tsx
@@ -42,4 +42,13 @@ describe('FindingsTable', () => {
     const firstVerdict = screen.getAllByRole('row')[1].querySelectorAll('td')[1];
     expect(firstVerdict).toHaveTextContent('fail');
   });
+
+  it('renders findings missing verdict without error', async () => {
+    const data = [...findings, { id: '3', rule: 'Rule C', evidence: 'Evidence 3' }];
+    render(<FindingsTable findings={data} />);
+    expect(screen.getByText('Rule C')).toBeInTheDocument();
+    const input = screen.getByPlaceholderText(/filter/i);
+    await userEvent.type(input, 'Rule C');
+    expect(screen.getAllByRole('row')).toHaveLength(2);
+  });
 });

--- a/apps/web/src/components/FindingsTable.tsx
+++ b/apps/web/src/components/FindingsTable.tsx
@@ -7,7 +7,7 @@ interface Finding {
   id: string;
   rule: string;
   evidence: string;
-  verdict: string;
+  verdict?: string;
 }
 
 interface FindingsTableProps {
@@ -33,17 +33,21 @@ export default function FindingsTable({ findings, sortState = { column: 'rule', 
     }));
   };
 
+  const toLower = (value?: string) => (value || '').toLowerCase();
+  const getValue = (f: Finding, column: 'rule' | 'verdict') =>
+    toLower(f[column as keyof Finding] as string | undefined);
+
   const filteredFindings = findings.filter(f => {
     const term = filter.toLowerCase();
     return (
       f.rule.toLowerCase().includes(term) ||
-      f.verdict.toLowerCase().includes(term)
+      getValue(f, 'verdict').includes(term)
     );
   });
 
   const sortedFindings = [...filteredFindings].sort((a, b) => {
-    const aVal = a[sort.column].toLowerCase();
-    const bVal = b[sort.column].toLowerCase();
+    const aVal = getValue(a, sort.column);
+    const bVal = getValue(b, sort.column);
     if (aVal < bVal) return sort.direction === 'asc' ? -1 : 1;
     if (aVal > bVal) return sort.direction === 'asc' ? 1 : -1;
     return 0;


### PR DESCRIPTION
## Summary
- allow findings without a verdict to render by defaulting to an empty string before filtering/sorting
- test that the table renders and filters entries that lack verdict values

## Testing
- `pnpm -C apps/web install --frozen-lockfile`
- `pnpm -C apps/web lint`
- `pnpm -C apps/web typecheck`
- `pnpm -C apps/web test --run`
- `pnpm -C apps/web build`


------
https://chatgpt.com/codex/tasks/task_e_68b6d6f7cbdc832fbe9865fcd4207d56