### PR TITLE
[API] add rulepack metadata endpoint

### DIFF
--- a/apps/api/blackletter_api/tests/unit/test_admin_rulepacks.py
+++ b/apps/api/blackletter_api/tests/unit/test_admin_rulepacks.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from blackletter_api.routers.admin import router as admin_router
+from blackletter_api.services.rulepack_loader import RulepackError
+
+app = FastAPI()
+app.include_router(admin_router)
+client = TestClient(app)
+
+
+def test_list_rulepacks_returns_metadata(monkeypatch) -> None:
+    def _fake() -> list[dict[str, str]]:
+        return [
+            {
+                "id": "pack1",
+                "version": "1.0",
+                "author": "tester",
+                "created_at": "2024-01-01",
+            }
+        ]
+
+    monkeypatch.setattr(
+        "blackletter_api.routers.admin.list_rulepack_metadata", _fake
+    )
+    res = client.get("/api/admin/rulepacks", headers={"X-User-Role": "admin"})
+    assert res.status_code == 200
+    assert res.json() == _fake()
+
+
+def test_list_rulepacks_handles_error(monkeypatch) -> None:
+    def _raise() -> list[dict[str, str]]:
+        raise RulepackError("not found")
+
+    monkeypatch.setattr(
+        "blackletter_api.routers.admin.list_rulepack_metadata", _raise
+    )
+    res = client.get("/api/admin/rulepacks", headers={"X-User-Role": "admin"})
+    assert res.status_code == 404
+    assert res.json()["detail"] == "not found"

--- a/docs/artifacts/admin_rulepacks_api.yaml
+++ b/docs/artifacts/admin_rulepacks_api.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+info:
+  title: Admin Rulepacks API
+  version: 1.0.0
+paths:
+  /api/admin/rulepacks:
+    get:
+      summary: List available rulepacks
+      description: Retrieve metadata for available rulepacks.
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    version:
+                      type: string
+                    author:
+                      type: string
+                      nullable: true
+                    created_at:
+                      type: string
+                      format: date-time
+                      nullable: true
+        "404":
+          description: No rulepacks available


### PR DESCRIPTION
## What changed
- add `/api/admin/rulepacks` endpoint returning rulepack metadata
- extend rulepack loader with metadata support
- document admin rulepacks API

## Why (risk, user impact)
Gives administrators visibility into available rulepacks; low risk as read-only.

## Tests & Evidence
- `pytest -q apps/api` *(fails: import errors during collection)*
- `pytest apps/api/blackletter_api/tests/unit/test_admin_rulepacks.py -q`

## Migration note
none

## Rollback plan
Revert the commits


------
https://chatgpt.com/codex/tasks/task_e_68b6cce51298832f82f0e8058b6c5277