### PR TITLE
[Docs] update API path references

### DIFF
--- a/docs/stories/EPIC2-STORY2.1.md
+++ b/docs/stories/EPIC2-STORY2.1.md
@@ -36,10 +36,10 @@
 - Follow existing error response patterns
 
 **File Locations:** [Source: shard-ready-arc/6-project-structure.md]
-- Rule pack loader: `apps/api/src/services/rulepack_loader.py`
-- Schema validation: `apps/api/src/schemas/rulepack.py` 
+- Rule pack loader: `apps/api/blackletter_api/services/rulepack_loader.py`
+- Schema validation: `apps/api/blackletter_api/schemas/rulepack.py`
 - Rule pack storage: `data/rulepacks/` directory
-- Admin endpoints: `apps/api/src/routers/admin.py`
+- Admin endpoints: `apps/api/blackletter_api/routers/admin.py`
 
 ### Technical Requirements
 - Python: Use Pydantic for YAML schema validation

--- a/docs/stories/EPIC2-STORY2.2.md
+++ b/docs/stories/EPIC2-STORY2.2.md
@@ -39,10 +39,10 @@
 - Consistent error response format with structured error codes
 
 **File Locations:** [Source: shard-ready-arc/6-project-structure.md]
-- Detector engine: `apps/api/src/services/detector_engine.py`
-- Verdict mapping: `apps/api/src/core/verdict_mapper.py`
-- Orchestration: `apps/api/src/services/analysis_orchestrator.py`
-- Analysis endpoints: `apps/api/src/routers/analysis.py`
+- Detector engine: `apps/api/blackletter_api/services/detector_engine.py`
+- Verdict mapping: `apps/api/blackletter_api/core/verdict_mapper.py`
+- Orchestration: `apps/api/blackletter_api/services/analysis_orchestrator.py`
+- Analysis endpoints: `apps/api/blackletter_api/routers/analysis.py`
 
 ### Technical Requirements
 - Python: Use dataclasses for detector results and verdict structures

--- a/docs/stories/EPIC2-STORY2.3.md
+++ b/docs/stories/EPIC2-STORY2.3.md
@@ -40,10 +40,10 @@
 - Redis 7.x: Cache compiled lexicon patterns for performance
 
 **File Locations:** [Source: shard-ready-arc/6-project-structure.md]
-- Lexicon engine: `apps/api/src/services/lexicon_analyzer.py`
-- Pattern matching: `apps/api/src/core/weak_language_detector.py`
+- Lexicon engine: `apps/api/blackletter_api/services/lexicon_analyzer.py`
+- Pattern matching: `apps/api/blackletter_api/core/weak_language_detector.py`
 - Lexicon data: `data/lexicons/weak_language_v0.yaml`
-- Admin endpoints: `apps/api/src/routers/admin.py` (extend existing)
+- Admin endpoints: `apps/api/blackletter_api/routers/admin.py` (extend existing)
 
 ### Technical Requirements
 - Pattern matching: Support regex patterns, case-insensitive matching

--- a/docs/stories/EPIC2-STORY2.4.md
+++ b/docs/stories/EPIC2-STORY2.4.md
@@ -41,10 +41,10 @@
 - FastAPI: Expose token metrics via admin endpoints
 
 **File Locations:** [Source: shard-ready-arc/6-project-structure.md]
-- Token ledger: `apps/api/src/services/token_ledger.py`
-- Budget monitoring: `apps/api/src/core/budget_monitor.py`
-- Metrics endpoints: `apps/api/src/routers/admin.py` (extend existing)
-- Configuration: `apps/api/src/config/token_settings.py`
+- Token ledger: `apps/api/blackletter_api/services/token_ledger.py`
+- Budget monitoring: `apps/api/blackletter_api/core/budget_monitor.py`
+- Metrics endpoints: `apps/api/blackletter_api/routers/admin.py` (extend existing)
+- Configuration: `apps/api/blackletter_api/config/token_settings.py`
 
 ### Technical Requirements
 - Performance: Token tracking must add <100ms to processing time
@@ -110,7 +110,7 @@
 - Security tests: Prevent token limit bypass attempts
 
 ## Artifacts
-* `apps/api/src/config/token_limits.yaml` - Default token limit configurations
+* `apps/api/blackletter_api/config/token_limits.yaml` - Default token limit configurations
 * `data/test-fixtures/large-documents/` - Documents for testing hard caps
 * `docs/artifacts/token_usage_schema.json` - Token ledger data model
 * `docs/artifacts/budget_monitoring_api.yaml` - Admin API specifications

--- a/docs/stories/EPIC3-STORY3.2.md
+++ b/docs/stories/EPIC3-STORY3.2.md
@@ -41,9 +41,9 @@
 - S3-compatible storage: Report archival and retrieval
 
 **File Locations:** [Source: shard-ready-arc/6-project-structure.md]
-- Report generator: `apps/api/src/services/report_generator.py`
-- Templates: `apps/api/src/templates/report_template.html`
-- Export endpoints: `apps/api/src/routers/reports.py`
+- Report generator: `apps/api/blackletter_api/services/report_generator.py`
+- Templates: `apps/api/blackletter_api/templates/report_template.html`
+- Export endpoints: `apps/api/blackletter_api/routers/reports.py`
 - Frontend trigger: `apps/web/src/components/ExportButton.tsx`
 
 ### Technical Requirements
@@ -110,8 +110,8 @@
 - Visual tests: PDF layout and formatting consistency
 
 ## Artifacts
-* `apps/api/src/templates/report_template.html` - Main report template
-* `apps/api/src/static/report_styles.css` - Report styling and branding
+* `apps/api/blackletter_api/templates/report_template.html` - Main report template
+* `apps/api/blackletter_api/static/report_styles.css` - Report styling and branding
 * `data/test-fixtures/export-samples/` - Sample generated reports
 * `docs/artifacts/report_format_spec.md` - Report structure documentation
 


### PR DESCRIPTION
## What changed
- replace outdated `apps/api/src` paths with `apps/api/blackletter_api` in GDPR rule engine stories

## Why (risk, user impact)
- keeps documentation aligned with current backend layout to avoid confusion for contributors

## Tests & Evidence
- `pytest apps/api/blackletter_api/tests/unit/test_rules_router.py -q` (fails: ImportError: cannot import name 'gemini_service')

## Migration note
- none

## Rollback plan
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68b6cce72134832f8d3585f1d3b42d11