### PR TITLE
[Docs] update upload flow file list

### DIFF
--- a/docs/stories/1.1-upload-job-orchestration.md
+++ b/docs/stories/1.1-upload-job-orchestration.md
@@ -77,5 +77,5 @@ dev_agent_record:
   agent_model: "grok-code-fast-1"
   debug_log_references: ""
   completion_notes: "Story 1.1 fully implemented with backend API, storage service, orchestration, frontend UI, and comprehensive tests. All acceptance criteria met."
-  file_list: "apps/api/blackletter_api/routers/contracts.py, apps/api/blackletter_api/routers/jobs.py, apps/api/blackletter_api/services/storage.py, apps/api/blackletter_api/services/tasks.py, apps/web/src/app/new/page.tsx, apps/web/src/lib/api.ts, apps/api/blackletter_api/tests/integration/test_upload_validation.py, apps/api/blackletter_api/tests/integration/test_job_polling_status.py"
+  file_list: "apps/api/blackletter_api/routers/contracts.py, apps/api/blackletter_api/routers/jobs.py, apps/api/blackletter_api/services/storage.py, apps/api/blackletter_api/services/tasks.py, apps/web/src/app/new/page.tsx, apps/web/src/app/new/page.test.tsx, apps/web/src/app/upload/page.tsx, apps/web/src/components/UploadDropzone.tsx, apps/web/src/components/UploadDropzone.test.tsx, apps/api/blackletter_api/tests/integration/test_upload_validation.py, apps/api/blackletter_api/tests/integration/test_job_polling_status.py"
 qa_results: ""


### PR DESCRIPTION
## What changed
- refresh upload orchestration story file list to reflect current frontend components and tests

## Why (risk, user impact)
- keeps documentation accurate so future agents reference correct files

## Tests & Evidence
- `pytest -q` *(fails: SyntaxError in rulepack_schema)*

## Migration note (alembic)
- none

## Rollback plan
- revert commit

------
https://chatgpt.com/codex/tasks/task_e_68b716dd4434832fb12a0ffb2e10c62c