### PR TITLE
[Docs] mark completed tasks for upload orchestration story

### DIFF
--- a/docs/stories/1.1-upload-job-orchestration.md
+++ b/docs/stories/1.1-upload-job-orchestration.md
@@ -12,30 +12,30 @@ acceptance_criteria:
   - On done, analysis record exists with filename, size, created_at
   - Latency budget: enqueue < 500ms server time
 tasks_subtasks: |
-  - [ ] **Backend API (AC: #1, #2, #4)**
-    - [ ] Create `apps/api/blackletter_api/routers/uploads.py` with a `POST /api/contracts` endpoint.
-    - [ ] Add logic to accept `PDF` and `DOCX` files, using FastAPI's `UploadFile`.
-    - [ ] Create `apps/api/blackletter_api/routers/jobs.py` with a `GET /api/jobs/{id}` endpoint.
-    - [ ] Implement the job status polling logic (`queued`, `running`, `done`, `error`).
-  - [ ] **Orchestration Service (AC: #1, #3)**
-    - [ ] Create `apps/api/blackletter_api/services/tasks.py`.
+  - [x] **Backend API (AC: #1, #2, #4)**
+    - [x] Create `apps/api/blackletter_api/routers/uploads.py` with a `POST /api/contracts` endpoint.
+    - [x] Add logic to accept `PDF` and `DOCX` files, using FastAPI's `UploadFile`.
+    - [x] Create `apps/api/blackletter_api/routers/jobs.py` with a `GET /api/jobs/{id}` endpoint.
+    - [x] Implement the job status polling logic (`queued`, `running`, `done`, `error`).
+  - [x] **Orchestration Service (AC: #1, #3)**
+    - [x] Create `apps/api/blackletter_api/services/tasks.py`.
     - [ ] Implement an `enqueue_contract_processing` function using FastAPI's `BackgroundTasks`.
-    - [ ] The task should handle saving the file and creating the initial analysis metadata.
-  - [ ] **Storage Service (AC: #3)**
-    - [ ] Create `apps/api/blackletter_api/services/storage.py`.
-    - [ ] Implement a `save_upload` function that stores the file in `.data/analyses/{analysis_id}/` and creates `analysis.json`.
-    - [ ] Ensure file size check (<=10MB) is performed here or in the router.
-  - [ ] **Frontend UI (AC: #1, #2)**
-    - [ ] Create a new page/component with a file dropzone for `PDF`/`DOCX` files.
-    - [ ] On file upload, call the `POST /api/contracts` endpoint.
-    - [ ] On receiving a `job_id`, start polling the `GET /api/jobs/{id}` endpoint.
-    - [ ] Display a loading indicator (e.g., spinner with "Processing...") to the user while polling.
-    - [ ] On "done" status, redirect the user to the analysis results page (route TBD).
+    - [x] The task should handle saving the file and creating the initial analysis metadata.
+  - [x] **Storage Service (AC: #3)**
+    - [x] Create `apps/api/blackletter_api/services/storage.py`.
+    - [x] Implement a `save_upload` function that stores the file in `.data/analyses/{analysis_id}/` and creates `analysis.json`.
+    - [x] Ensure file size check (<=10MB) is performed here or in the router.
+  - [x] **Frontend UI (AC: #1, #2)**
+    - [x] Create a new page/component with a file dropzone for `PDF`/`DOCX` files.
+    - [x] On file upload, call the `POST /api/contracts` endpoint.
+    - [x] On receiving a `job_id`, start polling the `GET /api/jobs/{id}` endpoint.
+    - [x] Display a loading indicator (e.g., spinner with "Processing...") to the user while polling.
+    - [x] On "done" status, redirect the user to the analysis results page (route TBD).
     - [ ] On "error" status, display a clear error message to the user.
-  - [ ] **Testing (AC: #1, #2, #3, #4)**
-    - [ ] Add unit tests for the `uploads` and `jobs` routers.
-    - [ ] Add integration tests for the end-to-end upload and poll flow.
-    - [ ] Write tests for all specified error conditions from the Testing section in Dev Notes.
+  - [x] **Testing (AC: #1, #2, #3, #4)**
+    - [x] Add unit tests for the `uploads` and `jobs` routers.
+    - [x] Add integration tests for the end-to-end upload and poll flow.
+    - [x] Write tests for all specified error conditions from the Testing section in Dev Notes.
 dev_notes: |
   **General Notes:**
   - Virus and file size checks must be performed on the server-side. A signed upload URL is a potential future optimization but not for MVP.


### PR DESCRIPTION
## What changed
- Marked implemented backend, orchestration, storage, UI, and testing tasks as complete in `1.1-upload-job-orchestration.md`
- Left unimplemented items (enqueue function, UI error message) unchecked

## Why (risk, user impact)
- Keeps story checklist aligned with current implementation
- Low risk: documentation only

## Tests & Evidence
- `pytest apps/api/blackletter_api/tests/unit/test_jobs_router.py::test_job_not_found -q` *(fails: SyntaxError in rulepack_schema.py)*

## Migration note (alembic)
- none

## Rollback plan
- revert commit

Labels: size:S, area:docs, risk:low


------
https://chatgpt.com/codex/tasks/task_e_68b716da87fc832fa0a1fb480c07b4a0