### PR TITLE
[Docs] align upload story with contracts router

### DIFF
--- a/docs/stories/1.1-upload-job-orchestration.md
+++ b/docs/stories/1.1-upload-job-orchestration.md
@@ -13,7 +13,7 @@ acceptance_criteria:
   - Latency budget: enqueue < 500ms server time
 tasks_subtasks: |
   - [ ] **Backend API (AC: #1, #2, #4)**
-    - [ ] Create `apps/api/blackletter_api/routers/uploads.py` with a `POST /api/contracts` endpoint.
+    - [ ] Create `apps/api/blackletter_api/routers/contracts.py` with a `POST /api/contracts` endpoint.
     - [ ] Add logic to accept `PDF` and `DOCX` files, using FastAPI's `UploadFile`.
     - [ ] Create `apps/api/blackletter_api/routers/jobs.py` with a `GET /api/jobs/{id}` endpoint.
     - [ ] Implement the job status polling logic (`queued`, `running`, `done`, `error`).
@@ -33,7 +33,7 @@ tasks_subtasks: |
     - [ ] On "done" status, redirect the user to the analysis results page (route TBD).
     - [ ] On "error" status, display a clear error message to the user.
   - [ ] **Testing (AC: #1, #2, #3, #4)**
-    - [ ] Add unit tests for the `uploads` and `jobs` routers.
+    - [ ] Add unit tests for the `contracts` and `jobs` routers.
     - [ ] Add integration tests for the end-to-end upload and poll flow.
     - [ ] Write tests for all specified error conditions from the Testing section in Dev Notes.
 dev_notes: |


### PR DESCRIPTION
## What changed
- Update Upload & Job Orchestration story to reference `contracts.py` router.
- Clarify Testing section to cover unit tests for the `contracts` and `jobs` routers.

## Why (risk, user impact)
- Keeps story instructions consistent with current API layout.
- Risk: low

## Tests & Evidence
- `pytest -q` *(fails: SyntaxError in `apps/api/blackletter_api/models/rulepack_schema.py` during collection)*

## Migration note
- none

## Rollback plan
- revert commit

cc @codex

------
https://chatgpt.com/codex/tasks/task_e_68b716d9d748832f9da46c9858304ed1