### PR TITLE
[Infra] fix pnpm setup order in azure static web apps workflow

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -19,14 +19,14 @@ jobs:
         with:
           submodules: true
           
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-          
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
           
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## What changed
- install pnpm before setting up Node.js in Azure Static Web Apps workflow to allow pnpm caching

## Why (risk, user impact)
- previous step order caused `setup-node` to fail with "pnpm" not found, blocking deployments
- risk: low

## Tests & Evidence
- `pnpm --version`
- `node --version`

## Migration note
- none

## Rollback plan
- revert this commit

cc @codex

------
https://chatgpt.com/codex/tasks/task_e_68b718a3ff58832f960eaa98ff954384