### PR TITLE
[Infra] use OIDC for ACR login

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -16,6 +16,9 @@ env:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     
     steps:
     - name: Checkout code
@@ -27,14 +30,12 @@ jobs:
     - name: Log in to Azure
       uses: azure/login@v1
       with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     - name: Log in to Azure Container Registry
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ env.REGISTRY }}
-        username: ${{ secrets.ACR_USERNAME }}
-        password: ${{ secrets.ACR_PASSWORD }}
+      run: az acr login --name blackletteracr
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v5


### PR DESCRIPTION
## What changed
- replace ACR username/password login with OIDC-based Azure auth
- use `az acr login` after `azure/login`
- drop ACR_USERNAME and ACR_PASSWORD secrets

## Why (risk, user impact)
- removes long-lived registry credentials
- leverages federated identity for secure deployments

## Tests & Evidence
- `python3 - <<'PY'\nimport yaml, sys\nwith open('.github/workflows/deploy-azure.yml') as f:\n    yaml.safe_load(f)\nprint('workflow syntax OK')\nPY`

## Migration note
none

## Rollback plan
- revert to previous workflow and restore credentials if deployment fails

------
https://chatgpt.com/codex/tasks/task_e_68b71f34bd10832fb3e1a632944c8108