### PR TITLE
Docs: refine metrics wall story

### DIFF
--- a/docs/stories/4.1-metrics-wall.md
+++ b/docs/stories/4.1-metrics-wall.md
@@ -1,23 +1,52 @@
 id: 4.1
 epic: 4
 title: Metrics Wall (latency, tokens, %LLM, explainability)
-status: draft
+status: review
 story: |
-  As an administrator, I want to view a dashboard of key metrics for the application so that I can monitor its performance, costs, and reliability.
+  As an administrator, I want a dashboard of key metrics so that I can monitor performance, cost, and reliability trends for the system.
 acceptance_criteria:
-  - Capture and display p95 latency, tokens_per_doc, %docs_invoking_LLM
-  - Explainability rate (findings with snippet+rule id)
-  - Admin‑only page
+  - `/admin/metrics` shows p95 latency, average tokens per document, percentage of analyses invoking LLMs, and explainability rate (findings with snippet + rule id).
+  - Metrics refresh at least every 60 seconds without page reload.
+  - Access is restricted to admins; unauthorized requests return `403`.
+  - API exposes aggregated metrics at `GET /api/admin/metrics` with shape `{p95_latency_ms, tokens_per_doc, pct_llm_used, explainability_rate}`.
+  - Historical data is retained for 30 days for charting.
 notes:
-  - Backend service to collect and expose metrics data.
-  - Frontend page (likely admin-only) to display metrics, possibly using charts.
-  - Integration with the token ledger (Story 2.4) for token metrics.
-  - Define how latency is measured (e.g., from job queue to completion).
-tasks: []
+  - Backend service collects metrics and aggregates them daily.
+  - Frontend page visualizes metrics using charts and auto-refresh.
+  - Integrates with token ledger (Story 2.4) for token counts.
+  - Latency measured from job enqueue to analysis completion.
+tasks: |
+  - [ ] **Backend**
+    - [ ] Instrument analysis pipeline for latency and token usage.
+    - [ ] Track explainability by counting findings with snippet and rule id.
+    - [ ] Persist daily aggregates and expose `GET /api/admin/metrics`.
+  - [ ] **Frontend**
+    - [ ] Create `/admin/metrics` dashboard with charts and auto-refresh.
+    - [ ] Restrict route to admin role.
+  - [ ] **Testing**
+    - [ ] Unit: aggregation helpers and access control.
+    - [ ] Integration: endpoint returns expected structure with sample data.
+    - [ ] UI: admin-only access enforced and charts render.
 dev_agent_record:
   proposed_tasks:
-    - backend: Instrument API to record p95 latency and tokens_per_doc
-    - backend: Collect %docs_invoking_LLM and explainability rate
-    - backend: Endpoint to aggregate and expose metrics
-    - frontend: Admin-only dashboard to display metrics
-    - tests: Metric collection and role-restricted access
+    - backend: instrument pipeline for latency and token usage; persist metrics; expose endpoint
+    - frontend: implement admin dashboard page with charts and auto-refresh
+    - tests: cover metric aggregation, API endpoint, and access control
+  dependencies:
+    - story: 2.4-token-ledger-caps
+  open_decisions:
+    - retention period beyond 30 days?
+    - chart library selection (e.g., Chart.js vs D3)
+
+### dev_spec
+
+- Instrumentation: middleware captures latency; token ledger feeds tokens_per_doc.
+- Storage: `models/metrics.py` stores daily aggregates (`date`, `p95_latency_ms`, `tokens_per_doc`, `pct_llm_used`, `explainability_rate`).
+- API: `GET /api/admin/metrics` returns latest aggregates; admin auth required.
+- Frontend: `/admin/metrics` page uses React Query and Chart.js for visualization.
+
+### qa_tests
+
+- Simulated analyses produce metrics persisted and served via API.
+- Unauthorized requests to metrics endpoint return `403`.
+- Dashboard renders metrics and auto-refreshes every minute.


### PR DESCRIPTION
## What changed
- fleshed out Metrics Wall story with detailed acceptance criteria, tasks, dev spec, and QA tests

## Why (risk, user impact)
- clarifies requirements for metrics dashboard; docs-only change is low risk

## Tests & Evidence
- `pytest -q` *(fails: SyntaxError in rulepack_schema and missing jsonschema module)*

## Migration note (alembic)
- none

## Rollback plan
- revert this commit

cc @codex

------
https://chatgpt.com/codex/tasks/task_e_68b74cec5468832fb995d0052d9b051b