### PR TITLE
[UI] add upload polling hook and status panels

### DIFF
--- a/apps/web/src/app/upload/page.tsx
+++ b/apps/web/src/app/upload/page.tsx
@@ -1,18 +1,39 @@
 "use client";
 
-import React from "react";
-import { UploadErrorBoundary, default as UploadDropzone } from "@/components/UploadDropzone";
+import React, { useCallback, useState } from "react";
+import UploadCard from "@/components/UploadCard";
+import UploadStatusPanel from "@/components/UploadStatusPanel";
+import ResultPanel from "@/components/ResultPanel";
+import useJobPolling from "@/lib/useJobPolling";
 
 export default function UploadPage() {
+  const [jobId, setJobId] = useState<string | null>(null);
+  const { result, error, abort } = useJobPolling(jobId ?? undefined);
+
+  const reset = useCallback(() => {
+    abort();
+    setJobId(null);
+  }, [abort]);
+
   return (
-    <div className="space-y-3">
+    <div className="space-y-4">
       <h1 className="text-2xl font-semibold">Upload a contract</h1>
-      <p className="text-sm text-muted-foreground">
-        Drop a file to create a new analysis.
-      </p>
-      <UploadErrorBoundary>
-        <UploadDropzone />
-      </UploadErrorBoundary>
+      <p className="text-sm text-muted-foreground">Drop a file to create a new analysis.</p>
+      {!jobId && <UploadCard onJobStart={setJobId} />}
+      {jobId && <UploadStatusPanel result={result} />}
+      {error && (
+        <div role="alert" className="rounded bg-yellow-100 p-2 text-sm text-yellow-800">
+          {error.message}
+        </div>
+      )}
+      {result?.status === "failed" && (
+        <button className="rounded border px-3 py-1 text-sm" onClick={reset}>
+          Retry
+        </button>
+      )}
+      {result?.status === "done" && result.analysisId && (
+        <ResultPanel analysisId={result.analysisId} onReset={reset} />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/ResultPanel.tsx
+++ b/apps/web/src/components/ResultPanel.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { useRouter } from "next/navigation";
+
+interface Props {
+  analysisId: string;
+  onReset: () => void;
+}
+
+export default function ResultPanel({ analysisId, onReset }: Props) {
+  const router = useRouter();
+  return (
+    <div className="mt-4 space-y-2">
+      <p className="text-sm">Upload complete.</p>
+      <div className="space-x-2">
+        <button
+          className="rounded bg-blue-600 px-3 py-1 text-sm text-white"
+          onClick={() => router.push(`/analyses/${analysisId}`)}
+        >
+          View analysis
+        </button>
+        <button
+          className="rounded border px-3 py-1 text-sm"
+          onClick={onReset}
+        >
+          Upload another
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/UploadCard.test.ts
+++ b/apps/web/src/components/UploadCard.test.ts
@@ -1,0 +1,19 @@
+import { validateFile, MAX_FILE_SIZE } from "./UploadCard";
+
+describe("validateFile", () => {
+  it("rejects unsupported file types", () => {
+    const file = new File(["data"], "test.txt", { type: "text/plain" });
+    expect(validateFile(file)).toMatch(/only pdf or docx/i);
+  });
+
+  it("rejects oversized files", () => {
+    const bigData = new Uint8Array(MAX_FILE_SIZE + 1);
+    const file = new File([bigData], "big.pdf", { type: "application/pdf" });
+    expect(validateFile(file)).toMatch(/10mb or less/i);
+  });
+
+  it("accepts valid files", () => {
+    const file = new File(["data"], "ok.pdf", { type: "application/pdf" });
+    expect(validateFile(file)).toBeNull();
+  });
+});

--- a/apps/web/src/components/UploadCard.tsx
+++ b/apps/web/src/components/UploadCard.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import React, { useRef, useState } from "react";
+
+export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const ACCEPTED_TYPES = ["application/pdf", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"];
+
+export function validateFile(file: File): string | null {
+  if (!ACCEPTED_TYPES.includes(file.type)) {
+    return "Only PDF or DOCX files are allowed";
+  }
+  if (file.size > MAX_FILE_SIZE) {
+    return "File must be 10MB or less";
+  }
+  return null;
+}
+
+interface UploadCardProps {
+  onJobStart: (jobId: string) => void;
+  disabled?: boolean;
+}
+
+export default function UploadCard({ onJobStart, disabled }: UploadCardProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleFiles = async (files: FileList | null) => {
+    const file = files?.[0];
+    if (!file) return;
+
+    const validationError = validateFile(file);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setError(null);
+    const body = new FormData();
+    body.append("file", file);
+    try {
+      const res = await fetch("/api/contracts", { method: "POST", body });
+      if (res.status >= 500) {
+        setError("Server error. Please try again later.");
+        return;
+      }
+      if (!res.ok) {
+        setError("Upload failed");
+        return;
+      }
+      const data = await res.json();
+      const id = data.job_id || data.id;
+      onJobStart(id);
+    } catch {
+      setError("Network error. Check your connection.");
+    }
+  };
+
+  const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
+  };
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleFiles(e.target.files);
+  };
+
+  return (
+    <div className="space-y-2">
+      {error && (
+        <div role="alert" className="rounded bg-red-100 p-2 text-sm text-red-800">
+          {error}
+        </div>
+      )}
+      <div
+        className="rounded-2xl border p-8 text-center cursor-pointer"
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={onDrop}
+        onClick={() => !disabled && inputRef.current?.click()}
+        role="button"
+        tabIndex={0}
+      >
+        Drop PDF or DOCX here
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".pdf,.docx"
+          className="hidden"
+          onChange={onChange}
+          disabled={disabled}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/UploadStatusPanel.test.tsx
+++ b/apps/web/src/components/UploadStatusPanel.test.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import UploadStatusPanel from "./UploadStatusPanel";
+import { JobPollingResult } from "@/lib/useJobPolling";
+
+describe("UploadStatusPanel", () => {
+  const renderWithStatus = (status: JobPollingResult["status"], progress?: number) =>
+    render(<UploadStatusPanel result={{ status, progress }} />);
+
+  it("shows queued state", () => {
+    const { getByText } = renderWithStatus("queued");
+    expect(getByText(/status: queued/i)).toBeInTheDocument();
+  });
+
+  it("shows progress when processing", () => {
+    const { container } = renderWithStatus("processing", 40);
+    const bar = container.querySelector("div.bg-blue-500");
+    expect(bar).toHaveStyle({ width: "40%" });
+  });
+
+  it("renders done without progress bar", () => {
+    const { queryByRole } = renderWithStatus("done");
+    expect(queryByRole("progressbar")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/UploadStatusPanel.tsx
+++ b/apps/web/src/components/UploadStatusPanel.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { JobPollingResult } from "@/lib/useJobPolling";
+
+interface Props {
+  result: JobPollingResult | null;
+}
+
+export default function UploadStatusPanel({ result }: Props) {
+  if (!result) return null;
+  const { status, progress } = result;
+  return (
+    <div className="mt-4" aria-live="polite">
+      <p className="text-sm font-medium">Status: {status}</p>
+      {status !== "done" && (
+        <div role="progressbar" className="mt-2 h-2 w-full rounded bg-gray-200">
+          {typeof progress === "number" ? (
+            <div
+              className="h-2 rounded bg-blue-500 transition-all"
+              style={{ width: `${progress}%` }}
+            />
+          ) : (
+            <div className="h-2 w-full animate-pulse rounded bg-blue-500" />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/useJobPolling.test.ts
+++ b/apps/web/src/lib/useJobPolling.test.ts
@@ -1,0 +1,53 @@
+import { renderHook, act } from "@testing-library/react";
+import { vi } from "vitest";
+import useJobPolling from "./useJobPolling";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+describe("useJobPolling", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("backs off after three failures", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockRejectedValue(new Error("net"));
+    // @ts-ignore
+    global.fetch = fetchMock;
+    renderHook(() => useJobPolling("job1"));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  it("aborts polling when abort is called", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(() => new Promise(() => {}));
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const { result } = renderHook(() => useJobPolling("job2"));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    act(() => {
+      result.current.abort();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/useJobPolling.ts
+++ b/apps/web/src/lib/useJobPolling.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type JobState = "queued" | "processing" | "done" | "failed";
+
+export interface JobPollingResult {
+  status: JobState;
+  analysisId?: string;
+  progress?: number;
+  eta?: number;
+}
+
+const mapStatus = (status?: string): JobState => {
+  if (status === "running" || status === "processing") return "processing";
+  if (status === "done") return "done";
+  if (status === "error" || status === "failed") return "failed";
+  return "queued";
+};
+
+export function useJobPolling(jobId?: string) {
+  const [result, setResult] = useState<JobPollingResult | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const attemptsRef = useRef(0);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const abort = useCallback(() => {
+    abortRef.current?.abort();
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+  }, []);
+
+  const poll = useCallback(async () => {
+    if (!jobId) return;
+    try {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      const res = await fetch(`/api/jobs/${jobId}`, {
+        signal: controller.signal,
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      const mapped = mapStatus(data.status);
+      setResult({
+        status: mapped,
+        analysisId: data.analysis_id,
+        progress: data.progress,
+        eta: data.eta,
+      });
+      setError(null);
+      attemptsRef.current = 0;
+      if (mapped === "queued" || mapped === "processing") {
+        timeoutRef.current = setTimeout(poll, 2000);
+      }
+    } catch (err) {
+      setError(err as Error);
+      attemptsRef.current += 1;
+      const delay =
+        attemptsRef.current <= 3
+          ? 2000
+          : 2000 * Math.pow(2, attemptsRef.current - 3);
+      timeoutRef.current = setTimeout(poll, delay);
+    }
+  }, [jobId]);
+
+  useEffect(() => {
+    if (!jobId) return;
+    poll();
+    return () => abort();
+  }, [jobId, poll, abort]);
+
+  return { result, error, abort };
+}
+
+export default useJobPolling;

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -1,0 +1,19 @@
+# Upload Page States and Polling
+
+The `/upload` page accepts PDF or DOCX files up to 10MB. Client-side validation
+shows inline messages for invalid type or size.
+
+After a file is posted to `/api/contracts`, the API responds with a `job_id` and
+a `202 Accepted` status. The front end polls `GET /api/jobs/{id}` every two
+seconds. After three consecutive failures the interval backs off exponentially
+(4s, 8s, ...).
+
+Job status values are mapped to four UI states:
+
+- **queued** – waiting for a worker
+- **processing** – worker running; progress bar shows `progress` if provided
+- **done** – analysis finished; link to view results
+- **failed** – error during processing; user may retry the upload
+
+If the API includes `eta` or `progress`, the progress bar is determinate;
+otherwise it falls back to an indeterminate animation.


### PR DESCRIPTION
## What changed
- add `useJobPolling` hook with exponential backoff and abort support
- refactor `/upload` into `UploadCard`, `UploadStatusPanel`, and `ResultPanel`
- validate file type/size with inline error messaging
- document upload states and polling behavior

## Why (risk, user impact)
- improves upload UX parity and robustness
- mitigates user confusion around job progress and failures
- risk: low; isolated frontend changes

## Tests & Evidence
- `pnpm -C apps/web install --frozen-lockfile`
- `pnpm -C apps/web lint`
- `pnpm -C apps/web typecheck`
- `pnpm -C apps/web test -- --run` *(fails: EvidenceDrawer.test.tsx, FindingsTable.test.tsx, app/new/page.test.tsx)*
- `pnpm -C apps/web build`

## Migration note
- none

## Rollback plan
- revert this PR

@codex

------
https://chatgpt.com/codex/tasks/task_e_68b73d178080832f92ba4cb9f459843b